### PR TITLE
Fixing signal definition, small ROOT macro changes

### DIFF
--- a/macros/ROOT_macros/TestMacro.cpp
+++ b/macros/ROOT_macros/TestMacro.cpp
@@ -17,9 +17,11 @@ void TestMacro() {
   float p_beam_polarization = 0.3;
   float luminosity = 2000;
   
+  string output_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/aQGCAnalysis/analyzer_plots/aQGCAnalyzer";
   aQGCAnalyzer analyzer;
   analyzer.setInputPaths( root_file_paths );
   analyzer.setBeamPolarizations( e_beam_polarization, p_beam_polarization );
   analyzer.setLuminosity( luminosity );
+  analyzer.setOutputDirectory( output_directory );
   analyzer.run();
 };

--- a/macros/ROOT_macros/analyzers/src/aQGCAnalyzer.cpp
+++ b/macros/ROOT_macros/analyzers/src/aQGCAnalyzer.cpp
@@ -125,7 +125,10 @@ void aQGCAnalyzer::performAnalysis(){
   auto count_WWsignal_inZZregion_with_cuts = rdf_WWsignal_inZZregion_with_cuts.Count();
   //----------------------------------------------------------------------------
 
-
+  auto h1_absCosThetaVstar_withcuts_WWsignal = rdf_WWsignal_with_cuts.Histo1D({"h1_absCosThetaVstar_withcuts_WWsignal", "V angle in VV system after cuts; |cos #theta_V^*|; Events", 100, 0, 1000}, "reco.VV_V_absCosThetaStar", "process_weight");
+  auto h1_absCosThetaVstar_withcuts_ZZsignal = rdf_ZZsignal_with_cuts.Histo1D({"h1_absCosThetaVstar_withcuts_ZZsignal", "V angle in VV system after cuts; |cos #theta_V^*|; Events", 100, 0, 1000}, "reco.VV_V_absCosThetaStar", "process_weight");
+  auto h1_absCosThetaVstar_withcuts_bkg      = rdf_bkg_with_cuts     .Histo1D({"h1_absCosThetaVstar_withcuts_bkg", "V angle in VV system after cuts; |cos #theta_V^*|; Events", 100, 0, 1000}, "reco.VV_V_absCosThetaStar", "process_weight");
+  
 
 
   //============================================================================
@@ -157,7 +160,7 @@ void aQGCAnalyzer::performAnalysis(){
   h1_VV_m_withcuts->Draw("hist same");
   h1_VV_m_withcuts_WWsignal->Draw("hist same");
   h1_VV_m_withcuts_ZZsignal->Draw("hist same");
-  canvas_h1->Print("/afs/desy.de/user/b/beyerjac/flc/VBS/aQGC_analysis/macros/ROOT_macros/test_plot.pdf");
+  canvas_h1->Print( ( this->getOutputDirectory() + "/VV_m.pdf").c_str() );
   delete canvas_h1;
   
   cout << endl;

--- a/macros/ROOT_macros/include/Analyzer.h
+++ b/macros/ROOT_macros/include/Analyzer.h
@@ -3,6 +3,7 @@
 
 #include "../src/SelectionCutTemplates.cpp"
 #include "../src/VariableCombinationTemplates.cpp"
+#include "../src/SystemHelper.cpp"
 
 using namespace ROOT;
 
@@ -20,10 +21,13 @@ class Analyzer {
     float m_e_beam_polarization {};
     float m_p_beam_polarization {};
 
+    string m_output_directory {"."};
+
   public:
     void setInputPaths( vector<string> &input_file_paths );
     void setBeamPolarizations( float &e_beam_polarization, float &p_beam_polarization );
     void setLuminosity( float &luminosity );
+    void setOutputDirectory( string &output_directory );
     
     void run();
 
@@ -40,6 +44,7 @@ class Analyzer {
     // Lambda can be used in dataframe to extract weight
   	function<float (TString, float, float, float)> getProcessWeightLambda(); 
 
+    string getOutputDirectory();
 };
 
 #endif

--- a/macros/ROOT_macros/include/EFTAnalyzer.h
+++ b/macros/ROOT_macros/include/EFTAnalyzer.h
@@ -4,7 +4,7 @@
 #include "../src/Analyzer.cpp"
 #include "../src/InputManager.cpp"
 #include "../src/PythonHelper.cpp"
-#include "../src/SystemHelper.cpp"
+
 
 class EFTAnalyzer : public Analyzer {
 

--- a/macros/ROOT_macros/include/SystemHelper.h
+++ b/macros/ROOT_macros/include/SystemHelper.h
@@ -2,13 +2,15 @@
 #define SYSTEMHELPER_H 1
 
 namespace SysHelp {
-  bool file_exists( string file_path );
+  bool pathExists( string path );
   
-  void hadd_rootfiles( string output_path, string input_paths, string options="", bool silent=true );
-  void make_Nevents_treecopy( string input_path, string tree_name, int N_events, string output_path, string options="", bool silent=true );
+  void haddROOTFiles( string output_path, string input_paths, string options="", bool silent=true );
+  void makeNEventsTreeCopy( string input_path, string tree_name, int N_events, string output_path, string options="", bool silent=true );
   
-  string extract_directory( string full_path );
-  string extract_filename( string full_path );
+  string extractDirectory( string full_path );
+  string extractFilename( string full_path );
+  
+  void createDirectory( string path );
 } 
 
 #endif

--- a/macros/ROOT_macros/src/Analyzer.cpp
+++ b/macros/ROOT_macros/src/Analyzer.cpp
@@ -15,6 +15,31 @@ void Analyzer::setLuminosity( float &luminosity ){
   m_luminosity = luminosity;
 }
 
+void Analyzer::setOutputDirectory( string &output_directory ){
+  m_output_directory = output_directory;
+  if ( ! SysHelp::pathExists(m_output_directory) ) {
+    cout << "Given output directory does not exist. Trying to create it..." << endl;
+    SysHelp::createDirectory(m_output_directory);
+    if ( SysHelp::pathExists(m_output_directory) ) {
+      cout << "Successfully created output directory!" << endl;
+    } else {
+      cout << "Something went wrong in creating output directory: " << m_output_directory << endl;
+      cout << "Exiting now." << endl;
+      exit(1);
+    }
+  }
+}
+
+//-------------------------------------------------------------------------------------------------
+
+string Analyzer::getOutputDirectory(){
+  if ( ! SysHelp::pathExists(m_output_directory) ) {
+    cout << "Something went wrong, trying to use non-existent output path! Exiting..." << endl;
+    exit(1);
+  } 
+  return m_output_directory;
+}
+
 //-------------------------------------------------------------------------------------------------
 
 void Analyzer::findAllFinalStates( TTree *info_chain ) {

--- a/macros/ROOT_macros/src/EFTAnalyzer.cpp
+++ b/macros/ROOT_macros/src/EFTAnalyzer.cpp
@@ -108,7 +108,7 @@ void EFTAnalyzer::setupDummyWeightsFile( string weight_file_path ){
 void EFTAnalyzer::searchForWeightFile( string file_path ){
   // Uses weight file convention to search for weight file to event file
   // WARNING: Has convention hardcoded!
-  string file_directory = SysHelp::extract_directory(file_path);
+  string file_directory = SysHelp::extractDirectory(file_path);
   string weight_directory = file_directory + "/rescan_output";
   
   InputManager weight_file_searcher;
@@ -152,11 +152,11 @@ void EFTAnalyzer::searchForWeightFiles() {
 string EFTAnalyzer::makeDummyCopy( string file_path) {
   /** Creates copy of the dummy tree and returns the copys path.
   */
-  string dummy_directory =  SysHelp::extract_directory(m_dummy_weights_file);
-  string file_name = SysHelp::extract_filename(file_path);
+  string dummy_directory =  SysHelp::extractDirectory(m_dummy_weights_file);
+  string file_name = SysHelp::extractFilename(file_path);
   string dummy_copy = dummy_directory + "/dummy_copy_" + file_name;
   
-  if ( SysHelp::file_exists(dummy_copy) ) {
+  if ( SysHelp::pathExists(dummy_copy) ) {
     cout << "Already have weight dummy, not overwriting: " << dummy_copy << endl;
   
   } else {
@@ -168,7 +168,7 @@ string EFTAnalyzer::makeDummyCopy( string file_path) {
     delete file;
     
     cout << "Creating dummy weight file: " << dummy_copy << endl;
-    SysHelp::make_Nevents_treecopy(m_dummy_weights_file, "weightsTree", N_entries, dummy_copy);
+    SysHelp::makeNEventsTreeCopy(m_dummy_weights_file, "weightsTree", N_entries, dummy_copy);
   }
   return dummy_copy;
   
@@ -180,12 +180,12 @@ string EFTAnalyzer::makeDummyCopy( string file_path) {
 // TODO Find way to combine with previous function or at least create common functions
 string EFTAnalyzer::combineFileAndWeight( string file_path, string weight_path ){
   
-  string dummy_directory = SysHelp::extract_directory(m_dummy_weights_file);
-  string file_name = SysHelp::extract_filename(file_path);
+  string dummy_directory = SysHelp::extractDirectory(m_dummy_weights_file);
+  string file_name = SysHelp::extractFilename(file_path);
   
   string combined_path = dummy_directory + "/combined_" + file_name;
 
-  if ( SysHelp::file_exists(combined_path) ) {
+  if ( SysHelp::pathExists(combined_path) ) {
     cout << "Already have combined file, not overwriting: " << combined_path << endl;
   } else {
     // Determine number of events the copy need
@@ -193,7 +193,7 @@ string EFTAnalyzer::combineFileAndWeight( string file_path, string weight_path )
     // ~/flc/VBS/aQGC_analysis/macros/ROOT_macros/run_in_old_root.sh
     
     string paths_to_combine = file_path + " " + weight_path;
-    SysHelp::hadd_rootfiles( combined_path , paths_to_combine, "-f" );
+    SysHelp::haddROOTFiles( combined_path , paths_to_combine, "-f" );
   }
   
   return combined_path;
@@ -212,7 +212,7 @@ void EFTAnalyzer::combineAllFiles() {
   // TODO Directory path should be settable option
   m_total_combined_path = "/afs/desy.de/group/flc/pool/beyerjac/tmp/total.root";
   
-  if ( SysHelp::file_exists(m_total_combined_path) ) {
+  if ( SysHelp::pathExists(m_total_combined_path) ) {
     cout << "Already have combined total file, not overwriting: " << m_total_combined_path << endl;
   } else {
 
@@ -233,7 +233,7 @@ void EFTAnalyzer::combineAllFiles() {
     }
     
     cout << "Combining all files to final file: " << m_total_combined_path << endl;
-    SysHelp::hadd_rootfiles( m_total_combined_path, all_combined_paths, "-f" );
+    SysHelp::haddROOTFiles( m_total_combined_path, all_combined_paths, "-f" );
   }
   
 }

--- a/macros/ROOT_macros/src/SystemHelper.cpp
+++ b/macros/ROOT_macros/src/SystemHelper.cpp
@@ -3,13 +3,13 @@
 //-------------------------------------------------------------------------------------------------
 
 
-bool SysHelp::file_exists( string file_path ){
-  return access( file_path.c_str(), F_OK ) != -1;
+bool SysHelp::pathExists( string path ){
+  return access( path.c_str(), F_OK ) != -1;
 }
 
 //-------------------------------------------------------------------------------------------------
 
-void SysHelp::hadd_rootfiles( string output_path, string input_paths, string options, bool silent){
+void SysHelp::haddROOTFiles( string output_path, string input_paths, string options, bool silent){
   string hadd_command = " hadd " + options + " " + output_path + " " + input_paths; // Create run_system_silent
   if ( silent ) { hadd_command += " >/dev/null"; }
   system(hadd_command.c_str());
@@ -17,7 +17,7 @@ void SysHelp::hadd_rootfiles( string output_path, string input_paths, string opt
 
 //-------------------------------------------------------------------------------------------------
 
-void SysHelp::make_Nevents_treecopy( string input_path, string tree_name, int N_events, string output_path, string options, bool silent){
+void SysHelp::makeNEventsTreeCopy( string input_path, string tree_name, int N_events, string output_path, string options, bool silent){
   string copy_command = "rooteventselector " + options + " -f 1 -l " + to_string(N_events) + " " + input_path + ":" + tree_name + " " + output_path;
   if ( silent ) { copy_command += " >/dev/null"; }
   system(copy_command.c_str());
@@ -25,15 +25,25 @@ void SysHelp::make_Nevents_treecopy( string input_path, string tree_name, int N_
 
 //-------------------------------------------------------------------------------------------------
 
-string SysHelp::extract_directory( string full_path ){
+string SysHelp::extractDirectory( string full_path ){
   return full_path.substr(0, full_path.find_last_of('/'));
 }
 
 //-------------------------------------------------------------------------------------------------
 
-string SysHelp::extract_filename( string full_path ){
-  string directory = SysHelp::extract_directory(full_path);
+string SysHelp::extractFilename( string full_path ){
+  string directory = SysHelp::extractDirectory(full_path);
   return full_path.substr(directory.size() + 1);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void SysHelp::createDirectory( string path ) {
+  // By default also creates necessary parent directories if possible
+  string mkdir_command = "mkdir -p " + path;
+  if ( ! SysHelp::pathExists(path) ) {
+    system(mkdir_command.c_str());
+  }
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/source/include/aQGCObservablesProcessor.h
+++ b/source/include/aQGCObservablesProcessor.h
@@ -70,6 +70,7 @@ private:
   
   void readInputInfo();
   
+  void CleanEventParameters();
   void CleanEvent();
 
   TLorentzVector getBoostedVector( TLorentzVector &to_boost, TLorentzVector &boost_system );
@@ -115,6 +116,7 @@ private:
   std::string         m_rootfilename {};
   
   // Process information
+  // REMEMBER: Everything declared here should be cleaned up in corresp. Clean... function
   
   TString  m_detector_model {};
   TString  m_process_name {};
@@ -126,7 +128,6 @@ private:
   float m_com_E {};
   
   // Observables 
-  
   int   m_V1_type {};
   float m_V1_m {};
   float m_V1_pT {};

--- a/source/src/AnalysisMCTruth.cpp
+++ b/source/src/AnalysisMCTruth.cpp
@@ -9,12 +9,17 @@ void aQGCObservablesProcessor::calculateMCTruth( MCParticleVec &mc_particles ) {
       Cuts for the signal definition are taken from previous ILD analyses.
   */
 
+  if (  m_e_polarization != -1 || m_p_polarization != +1 ) {
+    streamlog_out(DEBUG) << "In calculateMCTruth: Initial e+e- polarization not compatible with VBS!" << std::endl;
+    return;
+  }
+
   MCParticleVec initial_4q2nu   = this->findInitial4q2nu(mc_particles);
   MCParticleVec initial_quarks  = this->getQuarks( initial_4q2nu );
   MCParticleVec initial_nus     = this->getNeutrinos( initial_4q2nu );
   
   if ( initial_4q2nu.empty() ){
-    streamlog_out(DEBUG) << "In analyseMC: Event not of 4q2nu type!" << std::endl;
+    streamlog_out(DEBUG) << "In calculateMCTruth: Event not of 4q2nu type!" << std::endl;
     return;
   } 
 
@@ -28,7 +33,7 @@ void aQGCObservablesProcessor::calculateMCTruth( MCParticleVec &mc_particles ) {
   //  -> those with combined invariant mass < 100GeV
   //  -> those with generations other than electron neutrino bc e->W+nu always ends up with electron neutrino
   if ( VBpair_finder.getVBPairType() == 0 ) {
-    streamlog_out(DEBUG) << "In analyseMC: 4q state not signal like!" << std::endl;
+    streamlog_out(DEBUG) << "In calculateMCTruth: 4q state not signal like!" << std::endl;
     return;
   }
   
@@ -40,13 +45,13 @@ void aQGCObservablesProcessor::calculateMCTruth( MCParticleVec &mc_particles ) {
   float m_nunu = (nu1_tlv+nu2_tlv).M();
   
   if ( m_nunu<100 && fabs(nu1->getPDG())!=12 && fabs(nu2->getPDG())!=12 ) {
-    streamlog_out(DEBUG) << "In analyseMC: 2nu state not signal like!" << std::endl;
+    streamlog_out(DEBUG) << "In calculateMCTruth: 2nu state not signal like!" << std::endl;
     return;
   } 
   
   // Event is signal-like, now get the MC parameters
   m_signal_type = VBpair_finder.getVBPairType();
-  streamlog_out(DEBUG) << "In analyseMC: Event is of VB type " << m_signal_type << std::endl;
+  streamlog_out(DEBUG) << "In calculateMCTruth: Event is of VB type " << m_signal_type << std::endl;
   this->findVectorBosonObservables( VBpair_finder );
 }
 

--- a/source/src/CleanEvent.cpp
+++ b/source/src/CleanEvent.cpp
@@ -1,7 +1,21 @@
 #include "aQGCObservablesProcessor.h"
 
-void aQGCObservablesProcessor::CleanEvent() {
+//-------------------------------------------------------------------------------------------------
 
+void aQGCObservablesProcessor::CleanEventParameters() {
+  m_detector_model       = "";
+  m_process_name         = "";
+  
+  m_e_polarization       = 0;
+  m_p_polarization       = 0;
+  m_cross_section        = 0;
+  m_cross_section_error  = 0;
+  m_com_E                = 0;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void aQGCObservablesProcessor::CleanEvent() {
   m_V1_type     = 0;
   m_V1_m        = -999;
   m_V1_pT       = 0;
@@ -34,3 +48,5 @@ void aQGCObservablesProcessor::CleanEvent() {
   
   m_signal_type = 0;
 }
+
+//-------------------------------------------------------------------------------------------------

--- a/source/src/aQGCObservablesProcessor.cpp
+++ b/source/src/aQGCObservablesProcessor.cpp
@@ -79,6 +79,7 @@ void aQGCObservablesProcessor::processRunHeader( EVENT::LCRunHeader* run ) {
 
 void aQGCObservablesProcessor::processEvent( EVENT::LCEvent * event ) {
   m_event = event;
+  this->CleanEventParameters();
   this->readInputInfo(); // Read info about process
   
   // Basic idea: perform same analysis first on MC then on Recos


### PR DESCRIPTION
- Restore functional naming convention in ROOT macros.
- Add output directory to ROOT macros.
- Fix generator level signal identification in processor and extend clean-up.