### PR TITLE
Fix observables and preselection, add plots and counts

### DIFF
--- a/macros/Marlin_macros/get_setup_directory.sh
+++ b/macros/Marlin_macros/get_setup_directory.sh
@@ -10,7 +10,8 @@ fi
 if [[ ${COLLIDER_ENERGY} == "500" ]] ; then
   echo "/pnfs/desy.de/ilc/prod/ilc/mc-opt-3/ild/dst-merged/500-TDR_ws"
 elif [[ ${COLLIDER_ENERGY} == "1000" ]] ; then
-	echo "/pnfs/desy.de/ilc/prod/ilc/mc-opt-3/ild/dst-merged/1000-B1b_ws"
+  echo "/nfs/dust/ilc/group/ild/beyerjac/mc-opt-3_1TeV_DST/1000-B1b_ws"
+	# echo "/pnfs/desy.de/ilc/prod/ilc/mc-opt-3/ild/dst-merged/1000-B1b_ws"
 else 
 	echo "Error in get_setup_directory.sh: Unknown collider energy: ${COLLIDER_ENERGY}" 1>&2
 fi 

--- a/macros/ROOT_macros/TestMacro.cpp
+++ b/macros/ROOT_macros/TestMacro.cpp
@@ -15,7 +15,7 @@ void TestMacro() {
   
   float e_beam_polarization = -0.8;
   float p_beam_polarization = 0.3;
-  float luminosity = 2000;
+  float luminosity = 1000;
   
   string output_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/aQGCAnalysis/analyzer_plots/aQGCAnalyzer";
   aQGCAnalyzer analyzer;

--- a/macros/ROOT_macros/TestMacro.cpp
+++ b/macros/ROOT_macros/TestMacro.cpp
@@ -3,7 +3,7 @@
 
  
 void TestMacro() {
-  EnableImplicitMT(); // Allow multithreating in RDataFrame
+  EnableImplicitMT(5); // Allow multithreating in RDataFrame
   
   InputManager input_manager;
   input_manager.setInputDirectory( "/nfs/dust/ilc/group/ild/beyerjac/VBS/aQGCAnalysis/test_combined" );

--- a/macros/ROOT_macros/aQGCTestMacro.cpp
+++ b/macros/ROOT_macros/aQGCTestMacro.cpp
@@ -1,4 +1,5 @@
-#include "analyzers/src/aQGCSampleSMAnalyzer.cpp"
+#include "analyzers/src/EFTTester.cpp"
+// #include "analyzers/src/aQGCSampleSMAnalyzer.cpp"
 
 void aQGCTestMacro() {
   EnableImplicitMT(20); // Allow multithreating in RDataFrame
@@ -35,24 +36,25 @@ void aQGCTestMacro() {
   vector<string> root_file_paths {};
   input_manager.getFilePaths( root_file_paths );
   
+  
   // Now to the analysis!
   float e_beam_polarization = -0.8;
   float p_beam_polarization = 0.3;
-  float luminosity = 2000;
+  float luminosity = 1000;
   
-  // string output_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/aQGCAnalysis/analyzer_plots/EFTTester";
-  // EFTTester analyzer;  
-  // analyzer.setInputPaths( root_file_paths );
-  // analyzer.setBeamPolarizations( e_beam_polarization, p_beam_polarization );
-  // analyzer.setLuminosity( luminosity );
-  // analyzer.setOutputDirectory( output_directory );
-  // analyzer.run();
-  
-  string output_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/aQGCAnalysis/analyzer_plots/aQGCSampleSMAnalyzer";
-  aQGCSampleSMAnalyzer analyzer;  
+  string output_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/aQGCAnalysis/analyzer_plots/EFTTester";
+  EFTTester analyzer;  
   analyzer.setInputPaths( root_file_paths );
   analyzer.setBeamPolarizations( e_beam_polarization, p_beam_polarization );
   analyzer.setLuminosity( luminosity );
   analyzer.setOutputDirectory( output_directory );
   analyzer.run();
+  
+  // string output_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/aQGCAnalysis/analyzer_plots/aQGCSampleSMAnalyzer";
+  // aQGCSampleSMAnalyzer analyzer;  
+  // analyzer.setInputPaths( root_file_paths );
+  // analyzer.setBeamPolarizations( e_beam_polarization, p_beam_polarization );
+  // analyzer.setLuminosity( luminosity );
+  // analyzer.setOutputDirectory( output_directory );
+  // analyzer.run();
 };

--- a/macros/ROOT_macros/analyzers/src/EFTTester.cpp
+++ b/macros/ROOT_macros/analyzers/src/EFTTester.cpp
@@ -10,7 +10,7 @@ void EFTTester::performAnalysis(){
   auto event_weight_lambda = this->getEventWeightLambda();
 
   vector<pair<ROOT::RDF::RResultPtr<TH1D>, string>> th1s_w_leg{};
-  TLegend *leg = new TLegend( 0.6, 0.6, 0.9, 0.9 );
+  TLegend *leg = new TLegend( 0.55, 0.4, 0.9, 0.85 );
   for ( auto const& element: this->getParameterPointMap() ) {
     auto index = element.first;
     auto pp = element.second;
@@ -18,7 +18,7 @@ void EFTTester::performAnalysis(){
 
     auto h1_VV_m = rdf_with_event_weight.Histo1D({("h1_VV_m" + to_string(index)).c_str(), "Di-boson mass; m_{VV}; Events", 50, 0, 1000}, "mctruth.VV_m", ("event_weight" + to_string(index)).c_str());
 
-    string leg_entry = "FS0: " + to_string(pp.first) + "TeV^{-4}, FS1: " + to_string(pp.second) + "TeV^{-4}";
+    string leg_entry = "FS0: " + to_string(int(pp.first)) + "TeV^{-4}, FS1: " + to_string(int(pp.second)) + "TeV^{-4}";
     th1s_w_leg.push_back(make_pair(h1_VV_m, leg_entry));
   }
 
@@ -26,29 +26,23 @@ void EFTTester::performAnalysis(){
 
   cout << "Start plotting." << endl;
   TCanvas *canvas_h1 = new TCanvas("test", "", 0, 0, 600, 600);
+  canvas_h1->SetTopMargin(1.5);
   int colour_count = 1;
   THStack* all_VV_m = new THStack("all_VV_m", "Di-boson mass; m_{VV}; Events");
   
-  cout << "Doing SM:" << endl;
-  cout << "Coloring." << endl;
   h1_VV_m_SM->SetLineColor(colour_count++);
-  cout << "Adding." << endl;
   all_VV_m->Add(h1_VV_m_SM.GetPtr());
   leg->AddEntry(h1_VV_m_SM.GetPtr(), "Standard Model", "l");
   
-  cout << "Doing non-SM:" << endl;
   colour_count=30;
   for (auto & th1_w_leg: th1s_w_leg) {
-    cout << "Coloring." << endl;
     th1_w_leg.first->SetLineColor(colour_count++);
-    cout << "Adding." << endl;
     all_VV_m->Add(th1_w_leg.first.GetPtr());
     leg->AddEntry(th1_w_leg.first.GetPtr(), th1_w_leg.second.c_str(), "l");
   }
   
-  cout << "Drawing." << endl;
-  canvas_h1->cd()->SetLogy();
-  all_VV_m->Draw("hist");
+  // canvas_h1->cd()->SetLogy();
+  all_VV_m->Draw("hist nostack");
   leg->Draw();
   cout << "Save file." << endl;
   

--- a/macros/ROOT_macros/analyzers/src/aQGCAnalyzer.cpp
+++ b/macros/ROOT_macros/analyzers/src/aQGCAnalyzer.cpp
@@ -4,17 +4,18 @@
 
 void aQGCAnalyzer::performAnalysis(){
   // final cuts:
-  float V_m_min         = 50;
-  float V_m_max         = 110;
-  float V_pT_min        = 10;
-  float V_cosTheta_max  = 0.8;
+  // float V_m_min         = 50;
+  // float V_m_max         = 110;
+  // float V_pT_min        = 10;
+  // float V_cosTheta_max  = 0.8;
   
-  float VV_m_min        = 200;
-  float VV_m_max        = 400;
-  float VV_pT_min       = 10;
-  float VV_ET_min       = 10;
+  // float VV_m_min        = 200;
+  // float VV_m_max        = 400;
+  float VV_pT_min       = 40;
+  float VV_ET_min       = 150;
   
-  float m_recoil_min    = 100;
+  float m_recoil_min    = 200;
+  float recoil_cosTheta_max = 0.99;
   
   float y_34_min        = 0.0001;
   
@@ -22,21 +23,22 @@ void aQGCAnalyzer::performAnalysis(){
   float min_jetNparticles_min   = 2;
   float min_jetNcharged_min     = 3;
   
-  float leadEtrack_cosTheta_max = 2;
-  float leadEtrack_coneE_min    = 0.99;
+  float leadEtrack_cosTheta_max = 0.99;
+  float leadEtrack_coneE_min    = 2;
   
-  auto VMassCut                 = Cuts::getMinMaxCutLambda( V_m_min , V_m_max );
-  auto VpTCut                   = Cuts::getMinCutLambda( V_pT_min );
-  auto VAbsCosThetaCut          = Cuts::getMaxCutLambda( V_cosTheta_max );
-  auto VVMassCut                = Cuts::getMinMaxCutLambda( VV_m_min, VV_m_max );
+  // auto VMassCut                 = Cuts::getMinMaxCutLambda( V_m_min , V_m_max );
+  // auto VpTCut                   = Cuts::getMinCutLambda( V_pT_min );
+  // auto VAbsCosThetaCut          = Cuts::getMaxCutLambda( V_cosTheta_max );
+  // auto VVMassCut                = Cuts::getMinMaxCutLambda( VV_m_min, VV_m_max );
   auto VVpTCut                  = Cuts::getMinCutLambda( VV_pT_min );
   auto VVETCut                  = Cuts::getMinCutLambda( VV_ET_min );
   auto MRecoilCut               = Cuts::getMinCutLambda( m_recoil_min );
+  auto RecoilAbsCosThetaCut     = Cuts::getMinMaxCutLambda( -1.0*recoil_cosTheta_max , recoil_cosTheta_max );
   auto Y34Cut                   = Cuts::getMinCutLambda( y_34_min );
   auto JetECut                  = Cuts::getMinCutLambda( min_jetE_min );
   auto JetNParticlesCut         = Cuts::getMinCutLambda( min_jetNparticles_min );
   auto JetNChargedCut           = Cuts::getMinCutLambda( min_jetNcharged_min );
-  auto LeadETrackAbsCosThetaCut = Cuts::getMaxCutLambda( leadEtrack_cosTheta_max );
+  auto LeadETrackAbsCosThetaCut = Cuts::getMinMaxCutLambda( -1.0*leadEtrack_cosTheta_max , leadEtrack_cosTheta_max );
   auto LeadETrackConeECut       = Cuts::getMinCutLambda( leadEtrack_coneE_min );
   auto IsoLepsCut               = Cuts::getBoolCutLambda( false );
   
@@ -77,14 +79,16 @@ void aQGCAnalyzer::performAnalysis(){
   
   //----------------------------------------------------------------------------
   // Apply all selection cuts
-  auto rdf_data_after_cuts = rdf_with_process_weight.Filter( VMassCut, {"reco.V1_m"} )
-                                    .Filter( VMassCut, {"reco.V2_m"} )
-                                    .Filter( VAbsCosThetaCut, {"reco.V1_cosTheta"} )
-                                    .Filter( VAbsCosThetaCut, {"reco.V2_cosTheta"} )
-                                    .Filter( VVMassCut, {"reco.VV_m"} )
+  auto rdf_data_after_cuts = rdf_with_process_weight
+                                    // .Filter( VMassCut, {"reco.V1_m"} )
+                                    // .Filter( VMassCut, {"reco.V2_m"} )
+                                    // .Filter( VAbsCosThetaCut, {"reco.V1_cosTheta"} )
+                                    // .Filter( VAbsCosThetaCut, {"reco.V2_cosTheta"} )
+                                    // .Filter( VVMassCut, {"reco.VV_m"} )
                                     .Filter( VVpTCut, {"reco.VV_pT"} )
                                     .Filter( VVETCut, {"reco.VV_ET"} )
                                     .Filter( MRecoilCut, {"reco.m_recoil"} )
+                                    .Filter( RecoilAbsCosThetaCut, {"reco.cosTheta_recoil"} )
                                     .Filter( Y34Cut, {"reco.y_34"} )
                                     .Filter( JetECut, {"reco.min_jetE"} )
                                     .Filter( JetNParticlesCut, {"reco.min_jetNparticles"} )
@@ -151,6 +155,14 @@ void aQGCAnalyzer::performAnalysis(){
 
   //----------------------------------------------------------------------------
   // Histograms after cuts
+  auto h1_VmMean_withcuts_WWsignal  = rdf_WWsignal_with_cuts.Histo1D({"h1_VmMean_withcuts_WWsignal", "w/ cuts; m_{jj,1}+m_{jj,2}/2 [GeV]; Events", 70, 50, 120}, "recoVmMean", "process_weight");
+  auto h1_VmMean_withcuts_ZZsignal  = rdf_ZZsignal_with_cuts.Histo1D({"h1_VmMean_withcuts_ZZsignal", "w/ cuts; m_{jj,1}+m_{jj,2}/2 [GeV]; Events", 70, 50, 120}, "recoVmMean", "process_weight");
+  auto h1_VmMean_withcuts_bkg       = rdf_bkg_with_cuts.Histo1D({"h1_VmMean_withcuts_bkg", "w/ cuts; m_{jj,1}+m_{jj,2}/2 [GeV]; Events", 70, 50, 120}, "recoVmMean", "process_weight");
+  
+  auto h2_Vm_withcuts_WWsignal  = rdf_WWsignal_with_cuts.Histo2D({"h2_Vm_withcuts_WWsignal", "w/ cuts ; m_{jj,1} [GeV]; m_{jj,2} [GeV]; Events", 35, 50, 120, 35, 50, 120}, "reco.V1_m", "reco.V2_m", "process_weight");
+  auto h2_Vm_withcuts_ZZsignal  = rdf_ZZsignal_with_cuts.Histo2D({"h2_Vm_withcuts_ZZsignal", "w/ cuts ; m_{jj,1} [GeV]; m_{jj,2} [GeV]; Events", 35, 50, 120, 35, 50, 120}, "reco.V1_m", "reco.V2_m", "process_weight");
+  auto h2_Vm_withcuts_bkg       = rdf_bkg_with_cuts.Histo2D({"h2_Vm_withcuts_bkg", "w/ cuts ; m_{jj,1} [GeV]; m_{jj,2} [GeV]; Events", 35, 50, 120, 35, 50, 120}, "reco.V1_m", "reco.V2_m", "process_weight");
+  
   auto h1_VV_m_withcuts           = rdf_data_after_cuts.Histo1D({"h1_VV_m", "Di-boson mass after cuts; m_{VV}; Events", 30, 150, 450}, "reco.VV_m", "process_weight");
   auto h1_VV_m_withcuts_WWsignal  = rdf_WWsignal_with_cuts.Histo1D({"h1_VV_m_WWsignal", "Di-boson mass after cuts; m_{VV}; Events", 30, 150, 450}, "reco.VV_m", "process_weight");
   auto h1_VV_m_withcuts_ZZsignal  = rdf_ZZsignal_with_cuts.Histo1D({"h1_VV_m_ZZsignal", "Di-boson mass after cuts; m_{VV}; Events", 30, 150, 450}, "reco.VV_m", "process_weight");
@@ -368,6 +380,50 @@ void aQGCAnalyzer::performAnalysis(){
   delete h1_absCosThetaJetstar_combined_withcuts_ZZsignal;
   for (auto & deletable: to_delete) { delete deletable; }
   
+  
+  unique_ptr<TCanvas> canvas_VmMean (new TCanvas("VmMean", "", 0, 0, 700, 600));
+  canvas_VmMean->SetTopMargin(0.11);
+  canvas_VmMean->SetRightMargin(0.24);
+  unique_ptr<THStack> VmMean_stack (new THStack("VmMean", "; m_{jj,1}+m_{jj,2}/2 [GeV]; Events"));
+  unique_ptr<TLegend> VmMean_leg (new TLegend( 0.8, 0.76, 1.0, 0.9 ));
+  VmMean_leg->SetHeader("w/ cuts");
+  h1_VmMean_withcuts_WWsignal->SetLineColor(4);
+  h1_VmMean_withcuts_ZZsignal->SetLineColor(2);
+  VmMean_stack->Add(h1_VmMean_withcuts_WWsignal.GetPtr());
+  VmMean_stack->Add(h1_VmMean_withcuts_ZZsignal.GetPtr());
+  VmMean_stack->Add(h1_VmMean_withcuts_bkg.GetPtr());
+  VmMean_leg->AddEntry( h1_VmMean_withcuts_WWsignal.GetPtr(), "WW", "l" );
+  VmMean_leg->AddEntry( h1_VmMean_withcuts_ZZsignal.GetPtr(), "ZZ", "l" );
+  VmMean_leg->AddEntry( h1_VmMean_withcuts_bkg.GetPtr(), "bkg", "l" );
+  VmMean_stack->Draw("hist nostack");
+  VmMean_stack->GetYaxis()->SetMaxDigits(3);
+  VmMean_leg->Draw();
+  gPad->Modified();
+  gPad->Update();
+  canvas_VmMean->Print( ( this->getOutputDirectory() + "/VmMean.pdf").c_str() );
+
+
+
+  unique_ptr<TCanvas> canvas_Vm2D (new TCanvas("Vm2D", "", 0, 0, 700, 600));
+  canvas_Vm2D->SetRightMargin(0.24);
+  unique_ptr<TLegend> Vm2D_leg (new TLegend( 0.8, 0.76, 1.0, 0.9 ));
+  h2_Vm_withcuts_WWsignal->SetLineColor(4);
+  h2_Vm_withcuts_ZZsignal->SetLineColor(2);
+  Vm2D_leg->AddEntry( h2_Vm_withcuts_WWsignal.GetPtr(), "WW", "l" );
+  Vm2D_leg->AddEntry( h2_Vm_withcuts_ZZsignal.GetPtr(), "ZZ", "l" );
+  Vm2D_leg->AddEntry( h2_Vm_withcuts_bkg.GetPtr(), "bkg", "l" );
+  h2_Vm_withcuts_bkg->Draw("box same");
+  h2_Vm_withcuts_WWsignal->Draw("box same");
+  h2_Vm_withcuts_ZZsignal->Draw("box same");
+  h2_Vm_withcuts_bkg->GetYaxis()->SetMaxDigits(3);
+  Vm2D_leg->Draw();
+  gPad->Modified();
+  gPad->Update();
+  canvas_Vm2D->Print( ( this->getOutputDirectory() + "/Vm2D.pdf").c_str() );
+
+
+
+
   
   
   

--- a/macros/ROOT_macros/include/Analyzer.h
+++ b/macros/ROOT_macros/include/Analyzer.h
@@ -7,13 +7,16 @@
 
 using namespace ROOT;
 
+// TODO SOMEHOW REWRITE THIS SO THAT NO EVERY ANALYSIS NEEDS TO SEARCH FOR ALL FINAL STATES AND NEVENTS ETC
+// TODO (e.g. create separate class for that part which then can/has to be passed to the analyzer class on construction)
 class Analyzer {
   
   protected:
     vector<string> m_input_file_paths {};
-    RDataFrame* m_dataframe{};
+    RDataFrame* m_dataframe = nullptr;
     vector<TChain*> m_all_chains {};
     
+    set<string> m_final_states{};
     typedef map<pair<float,float>, int> pol_Nevents_map;
     map<string, pol_Nevents_map> m_final_state_Nevents{};
 
@@ -37,14 +40,22 @@ class Analyzer {
     virtual void performAnalysis() = 0;
     void clearMemory();
     
-    int getNProcessEvents( TString* process_name_ptr, float e_polarization, float p_polarization );
-    float getPolarizationWeight( float e_polarization, float p_polarization );
-    float getProcessWeight(  TString* process_name_ptr, float e_polarization, float p_polarization, float cross_section );
+    int getNProcessEvents( TString* process_name_ptr, float e_polarization, float p_polarization ) const;
+    float getPolarizationWeight( float e_polarization, float p_polarization ) const;
+    float getProcessWeight(  TString* process_name_ptr, float e_polarization, float p_polarization, float cross_section ) const;
     
     // Lambda can be used in dataframe to extract weight
-  	function<float (TString, float, float, float)> getProcessWeightLambda(); 
+  	function<float (TString, float, float, float)> getProcessWeightLambda() const; 
 
-    string getOutputDirectory();
+    string getOutputDirectory() const;
+    set<string> getFinalStatesSet() const;
+    
+    // Convenient typedefs for working with RDF
+    typedef ROOT::RDF::RResultPtr<ULong64_t> ResultCount;
+    typedef ROOT::RDF::RResultPtr<RDFDetail::SumReturnType_t<float>> ResultSumFloat;
+    typedef ROOT::RDF::RResultPtr<RDFDetail::SumReturnType_t<double>> ResultSumDouble;
+    typedef ROOT::RDF::RResultPtr<TH1D> ResultTH1D;
+    typedef ROOT::RDF::RResultPtr<TH2D> ResultTH2D;
 };
 
 #endif

--- a/macros/ROOT_macros/include/EFTAnalyzer.h
+++ b/macros/ROOT_macros/include/EFTAnalyzer.h
@@ -34,8 +34,8 @@ class EFTAnalyzer : public Analyzer {
     ParameterPoint getParameterPoint( int setting_index ) const;
     int getNParameterPoints() const;
     map<int, ParameterPoint> getParameterPointMap() const;
-    float getEventWeight( float event_weight, float process_weight );
-    function<float (float, float)> getEventWeightLambda();
+    float getEventWeight( float event_weight, float process_weight ) const;
+    function<float (float, float)> getEventWeightLambda() const;
     
     virtual void performAnalysis() = 0;
 };

--- a/macros/ROOT_macros/include/SelectionCutTemplates.h
+++ b/macros/ROOT_macros/include/SelectionCutTemplates.h
@@ -9,8 +9,10 @@ namespace Cuts {
   template<class ValueType> function<bool (ValueType)> getMinCutLambda(ValueType min_limit);
   template<class ValueType> function<bool (ValueType)> getMaxCutLambda(ValueType max_limit);
   template<class ValueType> function<bool (ValueType)> getMinMaxCutLambda(ValueType min_limit, ValueType max_limit);
-  function<bool (bool)> getBoolCutLambda(bool desired_outcome);
-  function<bool (int)>  getIntCutLambda(int desired_outcome);
+  function<bool (bool)>     getBoolCutLambda(bool desired_outcome);
+  function<bool (float)>    getFloatCutLambda(float desired_outcome);
+  function<bool (int)>      getIntCutLambda(int desired_outcome);
+  function<bool (TString)>  getStringTestLambda(TString desired_outcome);
 }
 
 #endif

--- a/macros/ROOT_macros/include/VariableCombinationTemplates.h
+++ b/macros/ROOT_macros/include/VariableCombinationTemplates.h
@@ -9,6 +9,7 @@ namespace VarComb {
   
   
   template<class ValueType> function<ValueType (ValueType, ValueType)> getPlusLambda();
+  template<class ValueType> function<ValueType (ValueType, ValueType)> getMinusLambda();
   template<class ValueType> function<ValueType (ValueType, ValueType)> getMeanLambda();
 }
 

--- a/macros/ROOT_macros/src/Analyzer.cpp
+++ b/macros/ROOT_macros/src/Analyzer.cpp
@@ -32,7 +32,7 @@ void Analyzer::setOutputDirectory( string &output_directory ){
 
 //-------------------------------------------------------------------------------------------------
 
-string Analyzer::getOutputDirectory(){
+string Analyzer::getOutputDirectory() const {
   if ( ! SysHelp::pathExists(m_output_directory) ) {
     cout << "Something went wrong, trying to use non-existent output path! Exiting..." << endl;
     exit(1);
@@ -40,12 +40,29 @@ string Analyzer::getOutputDirectory(){
   return m_output_directory;
 }
 
+set<string> Analyzer::getFinalStatesSet() const {
+  return m_final_states;
+}
+
 //-------------------------------------------------------------------------------------------------
 
 void Analyzer::findAllFinalStates( TTree *info_chain ) {
+  /* Structure of this function: 
+      - First find all final states and polarizations by rough search (assumes that no combination has less than 100 events!)
+      - Then makes RDataFrame count Nevents for each combination
+  */
+  // TODO THIS WORKS BUT CREATES HUGE OVERHEAD (RDF IS VERY SLOW FOR SOME REASON)
+  // TODO 1. Work out why RDF does not multithread
+  // TODO 2. Do this function based entirely on RDF!
+  
   if ( !m_final_state_Nevents.empty() ){
-    cout << "ERROR in Analyzer::findAllFinalStates : Searching final states, but they are already found!"  << endl;
+    cout << "WARNING in Analyzer::findAllFinalStates : Searching final states, but they are already found!"  << endl;
     return;
+  }
+  
+  if ( nullptr == m_dataframe ) {
+    cout << "ERROR in Analyzer::findAllFinalStates : No RDataFrame set!" << endl;
+    exit(1);
   }
   
   int N_total = info_chain->GetEntries();
@@ -55,29 +72,54 @@ void Analyzer::findAllFinalStates( TTree *info_chain ) {
   info_chain->SetBranchAddress("e_polarization", &e_polarization);
   info_chain->SetBranchAddress("p_polarization", &p_polarization);
   
-  // For each event determine if final state (incl. pol.) already captured.
-  // If so increment specific event counter, else create new one as 1.
+  // Structure similar to final mapping but with ResultCount (weird RDF thing)
+  vector<pair<string,pair<pair<float,float>, ResultCount>>> final_state_Nevents {};
+   
+  // Find all final state - polarisation combinations, then ask dataframe for N
   // -> Check only every 100th event to speed up (no file should have less...)
   for (int i=0; i<N_total; i+=100) {
     info_chain->GetEvent(i);
     string process_name = process_name_ptr->Data();
-    
+  
     // Test if final state already found
-    if ( m_final_state_Nevents.find(process_name) == m_final_state_Nevents.end() ) {
+    if ( m_final_states.find(process_name) == m_final_states.end() ) {
       cout  << "Found final state: " <<  process_name << endl;
-      m_final_state_Nevents[process_name] = pol_Nevents_map{};
-    }
+      m_final_states.insert(process_name);
+      m_final_state_Nevents[process_name] = pol_Nevents_map{}; // Prepare map for process entry
+    } 
     
+    // For letting RDF test for this process name
+    auto ProcessNameLambda = Cuts::getStringTestLambda(process_name);
+
     // Test if polarization already found for this final state
-    pol_Nevents_map* fs_pol_map = &m_final_state_Nevents[process_name]; 
     auto pol_pair = make_pair(e_polarization, p_polarization);
-    if ( fs_pol_map->find(pol_pair) == fs_pol_map->end() ) {
+    
+    // Check if process - pol combination is already in vector using a lambda function
+    auto GotProcessPol = [process_name, pol_pair](const pair<string,pair<pair<float,float>, ResultCount>>& element) {
+      return (element.first == process_name) && (element.second.first == pol_pair);
+    };
+    
+    if ( find_if(final_state_Nevents.begin(), final_state_Nevents.end(), GotProcessPol) == final_state_Nevents.end() ) {
       cout  << "Found final state - polarization pairing: " << process_name 
             << " " << e_polarization << " " << p_polarization << endl;
-      m_final_state_Nevents[process_name][pol_pair] = 1;
-    } else {
-      m_final_state_Nevents[process_name][pol_pair]++;
+      
+      auto ElectronPolTestLambda = Cuts::getFloatCutLambda(e_polarization);
+      auto PositronPolTestLambda = Cuts::getFloatCutLambda(p_polarization);
+
+      // This is the combination of process and polarisation -> push back object that tells RDF to count exactly that
+      auto Nevents_count = m_dataframe->Filter(ProcessNameLambda, {"process_name"}).Filter(ElectronPolTestLambda, {"e_polarization"}).Filter(PositronPolTestLambda, {"p_polarization"}).Count();
+      final_state_Nevents.push_back( make_pair(process_name, make_pair(pol_pair, Nevents_count)) );
     }
+  }
+  
+  // Now fill actually used map by making rdf count Nevents for each combination
+  for ( auto & fs_pol_count: final_state_Nevents) {
+    auto process_name   = fs_pol_count.first;
+    auto pol_count_pair = fs_pol_count.second;      
+    auto pol_pair       = pol_count_pair.first;   
+    // Trigger RDF to count the number of events for this process - pol combination
+    int Nevents         = *pol_count_pair.second;
+    m_final_state_Nevents[process_name][pol_pair] = Nevents;
   }
 }
 
@@ -96,15 +138,15 @@ void Analyzer::getCombinedDataframe() {
     truth_chain->Add( file_path.c_str() );
   }
   
-  this->findAllFinalStates( info_chain );
   
   info_chain->AddFriend(reco_chain, "reco");
   info_chain->AddFriend(mc_chain, "mcobs");
   info_chain->AddFriend(truth_chain, "mctruth");
   RDataFrame* befriended_dataframe = new RDataFrame(*info_chain);
   m_dataframe = befriended_dataframe;
-  
   m_all_chains = {info_chain, reco_chain, mc_chain, truth_chain};
+  
+  this->findAllFinalStates( info_chain );
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -133,7 +175,7 @@ void Analyzer::clearMemory(){
 
 //-------------------------------------------------------------------------------------------------
 
-int Analyzer::getNProcessEvents( TString* process_name_ptr, float e_polarization, float p_polarization ) {
+int Analyzer::getNProcessEvents( TString* process_name_ptr, float e_polarization, float p_polarization ) const {
   string process_name = process_name_ptr->Data();
   
   // Test if final state is registered
@@ -144,7 +186,7 @@ int Analyzer::getNProcessEvents( TString* process_name_ptr, float e_polarization
   }
   
   // Test if polarization is registered
-  pol_Nevents_map* fs_pol_map = &m_final_state_Nevents[process_name]; 
+  const pol_Nevents_map* fs_pol_map = &m_final_state_Nevents.at(process_name); 
   auto pol_pair = make_pair(e_polarization, p_polarization);
   if ( fs_pol_map->find(pol_pair) == fs_pol_map->end() ) {
     cout  << "ERROR in Analyzer::getNProcessEvents: Unknown process - pol pairing "
@@ -152,26 +194,26 @@ int Analyzer::getNProcessEvents( TString* process_name_ptr, float e_polarization
     return -1;
   } 
   
-  return m_final_state_Nevents[process_name][pol_pair];
+  return fs_pol_map->at(pol_pair);
 }
 
 //-------------------------------------------------------------------------------------------------
 
-float Analyzer::getPolarizationWeight( float e_polarization, float p_polarization ) {
-  return 0.5*( 1 + e_polarization * m_e_beam_polarization ) * 0.5*( 1 + p_polarization * m_p_beam_polarization );
+float Analyzer::getPolarizationWeight( float e_polarization, float p_polarization ) const {
+  return 0.5*( 1. + e_polarization * m_e_beam_polarization ) * 0.5*( 1. + p_polarization * m_p_beam_polarization );
 }
 
 //-------------------------------------------------------------------------------------------------
 
-float Analyzer::getProcessWeight( TString* process_name_ptr, float e_polarization, float p_polarization, float cross_section ){
+float Analyzer::getProcessWeight( TString* process_name_ptr, float e_polarization, float p_polarization, float cross_section ) const{
   float polarization_weight = this->getPolarizationWeight( e_polarization, p_polarization );
-  int N_process_events = getNProcessEvents( process_name_ptr, e_polarization, p_polarization );
+  int N_process_events = this->getNProcessEvents( process_name_ptr, e_polarization, p_polarization );
   return polarization_weight * ( cross_section * m_luminosity ) / float(N_process_events);
 }
 
 //-------------------------------------------------------------------------------------------------
 
-function<float (TString, float, float, float)> Analyzer::getProcessWeightLambda() {
+function<float (TString, float, float, float)> Analyzer::getProcessWeightLambda() const {
   return[this](TString process_name_ptr, float e_polarization, float p_polarization, float cross_section) {
     return this->getProcessWeight( &process_name_ptr, e_polarization, p_polarization, cross_section ); 
   };

--- a/macros/ROOT_macros/src/Analyzer.cpp
+++ b/macros/ROOT_macros/src/Analyzer.cpp
@@ -52,7 +52,7 @@ void Analyzer::findAllFinalStates( TTree *info_chain ) {
       - Then makes RDataFrame count Nevents for each combination
   */
   // TODO THIS WORKS BUT CREATES HUGE OVERHEAD (RDF IS VERY SLOW FOR SOME REASON)
-  // TODO 1. Work out why RDF does not multithread
+  // TODO 1. Work out why RDF does not multithread -> Pretty sure I found it.... DUE TO THREAD SAFETY BASICALLY IMPOSSIBLE WITHIN CLASS!
   // TODO 2. Do this function based entirely on RDF!
   
   if ( !m_final_state_Nevents.empty() ){

--- a/macros/ROOT_macros/src/EFTAnalyzer.cpp
+++ b/macros/ROOT_macros/src/EFTAnalyzer.cpp
@@ -251,7 +251,6 @@ void EFTAnalyzer::getCombinedDataframe() {
   TTree* truth_tree   = (TTree*)m_combined_file->Get("mcTruthTree");
   TTree* weight_tree  = (TTree*)m_combined_file->Get("weightsTree");
   
-  this->findAllFinalStates( info_tree );
   
   info_tree->AddFriend(reco_tree, "reco");
   info_tree->AddFriend(mc_tree, "mcobs");
@@ -260,6 +259,8 @@ void EFTAnalyzer::getCombinedDataframe() {
   
   cout << "Creating RDataFrame." << endl;
   m_dataframe = new RDataFrame(*info_tree);
+  
+  this->findAllFinalStates( info_tree );
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -305,13 +306,13 @@ map<int, pair<float, float>> EFTAnalyzer::getParameterPointMap() const{
 
 //-------------------------------------------------------------------------------------------------
 
-float EFTAnalyzer::getEventWeight( float event_weight, float process_weight ){
+float EFTAnalyzer::getEventWeight( float event_weight, float process_weight ) const {
   return event_weight * process_weight;
 }
 
 //-------------------------------------------------------------------------------------------------
 
-function<float (float, float)> EFTAnalyzer::getEventWeightLambda(){
+function<float (float, float)> EFTAnalyzer::getEventWeightLambda() const{
   return[this](float event_weight, float process_weight) {
     return this->getEventWeight( event_weight, process_weight ); 
   };

--- a/macros/ROOT_macros/src/SelectionCutTemplates.cpp
+++ b/macros/ROOT_macros/src/SelectionCutTemplates.cpp
@@ -36,10 +36,25 @@ function<bool (bool)> Cuts::getBoolCutLambda(bool desired_outcome) {
 
 //------------------------------------------------------------------------------
 
+function<bool (float)> Cuts::getFloatCutLambda(float desired_outcome) {
+  return [desired_outcome](float value) { 
+    return value == desired_outcome; };
+}
+
+//------------------------------------------------------------------------------
+
 function<bool (int)> Cuts::getIntCutLambda(int desired_outcome) {
   return [desired_outcome](int value) { 
     bool value_as_bool = bool(value); // Will be true for all non-zero ints
     return value == desired_outcome; };
+}
+
+//------------------------------------------------------------------------------
+
+function<bool (TString)> Cuts::getStringTestLambda(TString desired_outcome) {
+  return [desired_outcome](TString value){ 
+    return value == desired_outcome; 
+  };
 }
 
 //------------------------------------------------------------------------------

--- a/macros/ROOT_macros/src/VariableCombinationTemplates.cpp
+++ b/macros/ROOT_macros/src/VariableCombinationTemplates.cpp
@@ -15,6 +15,15 @@ function<ValueType (ValueType, ValueType)> VarComb::getPlusLambda() {
 //------------------------------------------------------------------------------
 
 template<class ValueType> 
+function<ValueType (ValueType, ValueType)> VarComb::getMinusLambda() {
+  return [] (ValueType var_1, ValueType var_2) {
+     return var_1 - var_2;
+  };
+}
+
+//------------------------------------------------------------------------------
+
+template<class ValueType> 
 function<ValueType (ValueType, ValueType)> VarComb::getMeanLambda() {
   return [] (ValueType var_1, ValueType var_2) {
      return ValueType( (var_1 + var_2)/2.0 );

--- a/source/include/ObservableExtractionTemplates.tpp
+++ b/source/include/ObservableExtractionTemplates.tpp
@@ -59,6 +59,7 @@ void aQGCObservablesProcessor::findVectorBosonObservables( VectorBosonPairFinder
   TLorentzVector collision_system_tlv ( m_com_E*sin(0.014/2.0), 0, 0, m_com_E );
   TLorentzVector recoil_tlv  = collision_system_tlv - VV_tlv;
   m_recoil_m  = recoil_tlv.M();
+  m_recoil_cosTheta = recoil_tlv.CosTheta();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/source/include/aQGCObservablesProcessor.h
+++ b/source/include/aQGCObservablesProcessor.h
@@ -145,6 +145,7 @@ private:
   float m_VV_pT {};
   float m_VV_ET {};
   float m_recoil_m {};
+  float m_recoil_cosTheta {};
   
   float m_VV_V_absCosThetaStar {};
   

--- a/source/src/CleanEvent.cpp
+++ b/source/src/CleanEvent.cpp
@@ -33,6 +33,7 @@ void aQGCObservablesProcessor::CleanEvent() {
   m_VV_pT = 0;
   m_VV_ET    = -999;
   m_recoil_m  = -999;
+  m_recoil_cosTheta = -999;
   
   m_VV_V_absCosThetaStar = 999;
 

--- a/source/src/TFileContent.cpp
+++ b/source/src/TFileContent.cpp
@@ -23,6 +23,7 @@ void aQGCObservablesProcessor::setObservablesBranches( TTree* tree ){
   tree->Branch( "VV_pT",  &m_VV_pT, "VV_pT/F");
   tree->Branch( "VV_ET",   &m_VV_ET,    "VV_ET/F" );
   tree->Branch( "m_recoil", &m_recoil_m,  "m_recoil/F" );
+  tree->Branch( "cosTheta_recoil", &m_recoil_cosTheta,  "cosTheta_recoil/F" );
   
   // Observables in boosted combined VV frame
   tree->Branch( "VV_V_absCosThetaStar",  &m_VV_V_absCosThetaStar, "VV_V_absCosThetaStar/F");


### PR DESCRIPTION
- Add plots for individual final states. 
- Add lambdas for variable comparisons in plotting. 
- Repair finding of number of events.
- In processor add cosTheta of recoil. 
- In aQGCAnalyzer change preselection to correct values and variables.
- Add plots for reconstructed WW and ZZ regions.
- Add counts for individual final states and correct the histos.