### PR TITLE
Correct lib path in TJJetRecoParticleFinder Readme

### DIFF
--- a/FinalStateAnalysis/TJJetRecoParticleFinder/Readme.md
+++ b/FinalStateAnalysis/TJJetRecoParticleFinder/Readme.md
@@ -20,7 +20,7 @@ cd scripts
 To use the processor in `Marlin` on must add the path of the compiled library to the `MARLIN_DLL` variable:
 ```shell
 cd ../lib
-MARLIN_DLL=$MARLIN_DLL:$(pwd)/libJakobsVBSProcessor.so
+MARLIN_DLL=$MARLIN_DLL:$(pwd)/libTJJetRecoParticleFinder.so
 ```
 
 ### How to run the processor


### PR DESCRIPTION
- Correct the library name in the TJJetRecoParticleFinder Readme.