### PR TITLE
Create low mvv samples

### DIFF
--- a/FinalStateAnalysis/analysis/comparisons/Helpers/Helpers.hpp
+++ b/FinalStateAnalysis/analysis/comparisons/Helpers/Helpers.hpp
@@ -1,0 +1,16 @@
+namespace Helpers {
+
+//------------------------------------------------------------------------------
+
+void saveCanvas(shared_ptr<TCanvas> canvas, string output_base,
+                vector<string> extensions = {"pdf", "jpg", "C", "root"}) {
+  /** Save the given canvas for in all given extensions.
+   **/
+  for (const auto &extension : extensions) {
+    canvas->Print((output_base + "." + extension).c_str());
+  }
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace Helpers

--- a/FinalStateAnalysis/analysis/comparisons/comparison_highlowQ2_samples/create_highlowQ2_comparison.cpp
+++ b/FinalStateAnalysis/analysis/comparisons/comparison_highlowQ2_samples/create_highlowQ2_comparison.cpp
@@ -1,0 +1,295 @@
+// WARNING: Needs to be run with ROOT 6.14 or newer! (Else creating .C files is a meeeeeess)
+
+float string_to_float( string str ) {
+  return strtof((str).c_str(),0);
+}
+
+
+shared_ptr<TLatex> add_ILD_mark( shared_ptr<TCanvas> canvas, Double_t x0, Double_t y0, Float_t text_size=0.25 ) {
+  canvas->cd();
+  shared_ptr<TLatex> ild_tex (new TLatex(x0,y0,"ILD"));
+  ild_tex->SetName( (string(canvas->GetName()) + "_ildlogo").c_str() );
+  ild_tex->SetTextSize(text_size);
+  ild_tex->SetTextFont(62);
+  ild_tex->SetLineWidth(2);
+  ild_tex->Draw();
+  return ild_tex;
+}
+
+shared_ptr<TLatex> add_prelim_mark( shared_ptr<TCanvas> canvas, Double_t x0, Double_t y0, Float_t text_size=0.2 ) {
+  canvas->cd();
+  shared_ptr<TLatex> prelim_tex (new TLatex(x0,y0,"preliminary"));
+  prelim_tex->SetName( (string(canvas->GetName()) + "_prelim_text").c_str() );
+  prelim_tex->SetTextSize(text_size);
+  prelim_tex->SetTextFont(42);
+  prelim_tex->SetLineWidth(2);
+  prelim_tex->Draw();
+  return prelim_tex;
+}
+
+void adjust_canvas_left_to_square_pad(shared_ptr<TCanvas> canvas) {
+  double vertical_square_fraction   = 1.0 - canvas->GetTopMargin() - canvas->GetBottomMargin();
+  double width_to_height_ratio      = double(canvas->GetWindowWidth()) / double(canvas->GetWindowHeight()); 
+  double horizontal_square_fraction = vertical_square_fraction / width_to_height_ratio;
+  double left_margin = 1.0 - canvas->GetRightMargin() - horizontal_square_fraction;
+  canvas->SetLeftMargin(left_margin);
+}
+
+void scale_canvas_constant_pad(shared_ptr<TCanvas> canvas, double scale, string side="top") {
+  /** Rescales one side of the canvas while keeping the pad size constant (by adjusting the margins)
+  */
+  
+  // Way to read current canvas size depends on if it was set once before 
+  double current_canvas_width  = canvas->GetXsizeUser();
+  double current_canvas_height = canvas->GetYsizeUser();
+  if ( current_canvas_width == 0 ) {
+    current_canvas_width  = canvas->GetWw();
+    current_canvas_height = canvas->GetWh();
+  }
+  
+  if ( side == "top" ) {
+    double new_top_margin      = 1.0 - 1.0/scale * ( 1.0 - canvas->GetTopMargin() ) ;
+    double new_bottom_margin   = canvas->GetBottomMargin() / scale;
+    canvas->Size(current_canvas_width, current_canvas_height * scale);
+    canvas->SetTopMargin(new_top_margin);
+    canvas->SetBottomMargin(new_bottom_margin);
+  } else if ( side == "bottom" ) {
+    double new_bottom_margin      = 1.0 - 1.0/scale * ( 1.0 - canvas->GetBottomMargin() ) ;
+    double new_top_margin   = canvas->GetTopMargin() / scale;
+    canvas->Size(current_canvas_width, current_canvas_height * scale);
+    canvas->SetBottomMargin(new_bottom_margin);
+    canvas->SetTopMargin(new_top_margin);
+  } else if ( side == "left" ) {
+    double new_left_margin    = 1.0 - 1.0/scale * ( 1.0 - canvas->GetLeftMargin() ) ;
+    double new_right_margin   = canvas->GetRightMargin() / scale;
+    canvas->Size(current_canvas_width * scale, current_canvas_height);
+    canvas->SetLeftMargin(new_left_margin);
+    canvas->SetRightMargin(new_right_margin);
+  } else if ( side == "right" ) {
+    double new_right_margin    = 1.0 - 1.0/scale * ( 1.0 - canvas->GetRightMargin() ) ;
+    double new_left_margin   = canvas->GetLeftMargin() / scale;
+    canvas->Size(current_canvas_width * scale, current_canvas_height);
+    canvas->SetRightMargin(new_right_margin);
+    canvas->SetLeftMargin(new_left_margin);
+  } else {
+    cout << "  WARNING in scale_canvas_constant_pad: Unknown side " << side << endl;
+    return;
+  }
+  gPad->Modified();
+  gPad->Update();
+}
+
+void create_highlowQ2_comparison() {
+  // Standard ROOT plot setting
+  gROOT->Reset();
+  gStyle->SetOptStat(0);
+  TH2::SetDefaultSumw2();
+
+  // string pool_dir = "/afs/desy.de/group/flc/pool/beyerjac"
+  string pool_dir = "/home/jakob/Documents/DESY/MountPoints/POOLMount";
+  string lowQ2_directory = pool_dir + "/VBS/nunu_hadron/lowQ2range/v02-00-02_l5_o1_v02_output/all_signals_plots/";
+  string highQ2_directory = pool_dir + "/VBS/nunu_hadron/highQ2range/v02-00-02_l5_o1_v02_output/all_signals_plots/";
+  string lowQ2_directory_jets = pool_dir + "/VBS/nunu_hadron/lowQ2range/v02-00-02_l5_o1_v02_output/individual_quarks/";
+  string highQ2_directory_jets = pool_dir + "/VBS/nunu_hadron/highQ2range/v02-00-02_l5_o1_v02_output/individual_quarks/";
+  string output_dir   = pool_dir + "/VBS/nunu_hadron/comparisons/comparison_highlowQ2_samples/";
+
+  shared_ptr<TFile> file_lowQ2             = make_shared<TFile>( (lowQ2_directory + "./_all_TH1Ds.root").c_str() ) ;
+  shared_ptr<TFile> file_highQ2             = make_shared<TFile>( (highQ2_directory + "./_all_TH1Ds.root").c_str() ) ;
+  shared_ptr<TFile> file_lowQ2_jets        = make_shared<TFile>( (lowQ2_directory_jets + "./_all_TH1Ds.root").c_str() ) ;
+  shared_ptr<TFile> file_highQ2_jets        = make_shared<TFile>( (highQ2_directory_jets + "./_all_TH1Ds.root").c_str() ) ;
+  vector<shared_ptr<TFile>> closables {file_lowQ2, file_highQ2, file_lowQ2_jets, file_highQ2_jets};
+  
+  TH1D* true_pair_E_lowQ2 = (TH1D*)file_lowQ2->Get("true_pair_E");
+  TH1D* true_pair_E_highQ2 = (TH1D*)file_highQ2->Get("true_pair_E");
+  TH1D* true_pair_theta_lowQ2 = (TH1D*)file_lowQ2->Get("true_pair_theta");
+  TH1D* true_pair_theta_highQ2 = (TH1D*)file_highQ2->Get("true_pair_theta");
+  TH1D* jet_E_lowQ2 = (TH1D*)file_lowQ2_jets->Get("jet_E_nocuts_signal");
+  TH1D* jet_E_highQ2 = (TH1D*)file_highQ2_jets->Get("jet_E_nocuts_signal");
+  TH1D* jet_theta_lowQ2 = (TH1D*)file_lowQ2_jets->Get("jet_theta_nocuts_signal");
+  TH1D* jet_theta_highQ2 = (TH1D*)file_highQ2_jets->Get("jet_theta_nocuts_signal");
+  
+  vector<TObject*> deletables {true_pair_E_lowQ2,true_pair_E_highQ2,true_pair_theta_lowQ2,true_pair_theta_highQ2,jet_E_lowQ2,jet_E_highQ2,jet_theta_lowQ2,jet_theta_highQ2};
+  
+  unique_ptr<TColor> orange { new TColor( 9024, 241./256., 163./256., 64./256. ) } ;
+  unique_ptr<TColor> violet { new TColor( 9124, 153./256., 142./256., 195./256. ) } ;
+  // ---------------------------------------------------------------------------
+  
+  // ---------------------------------------------------------------------------
+  double canvas_comp_true_pair_E_height = 1200;
+  double canvas_comp_true_pair_E_width  = 1200;
+
+  shared_ptr<TCanvas> canvas_comp_true_pair_E (new TCanvas("canvas_comp_true_pair_E", "", 0, 0, canvas_comp_true_pair_E_width, canvas_comp_true_pair_E_height));
+  shared_ptr<THStack> stack_comp_true_pair_E = make_shared<THStack>( "comp_true_pair_E", "; E_{V(qq)} [GeV]; a.u." );
+
+  TH1D* clone_true_pair_E_lowQ2 = (TH1D*)true_pair_E_lowQ2->Clone();  clone_true_pair_E_lowQ2->SetName((string(clone_true_pair_E_lowQ2->GetName())+"_clone").c_str());  deletables.push_back(clone_true_pair_E_lowQ2); clone_true_pair_E_lowQ2->Scale(1.0/clone_true_pair_E_lowQ2->Integral()); clone_true_pair_E_lowQ2->Rebin(4);
+  TH1D* clone_true_pair_E_highQ2 = (TH1D*)true_pair_E_highQ2->Clone();  clone_true_pair_E_highQ2->SetName((string(clone_true_pair_E_highQ2->GetName())+"_clone").c_str());  deletables.push_back(clone_true_pair_E_highQ2); clone_true_pair_E_highQ2->Scale(1.0/clone_true_pair_E_highQ2->Integral()); clone_true_pair_E_highQ2->Rebin(4);
+  
+  stack_comp_true_pair_E->Add(clone_true_pair_E_lowQ2);  clone_true_pair_E_lowQ2->SetLineColor(9124);    clone_true_pair_E_lowQ2->SetLineWidth(3);  clone_true_pair_E_lowQ2->SetLineStyle(1);
+  stack_comp_true_pair_E->Add(clone_true_pair_E_highQ2);  clone_true_pair_E_highQ2->SetLineColor(9024);   clone_true_pair_E_highQ2->SetLineWidth(3);  clone_true_pair_E_highQ2->SetLineStyle(1);
+  // stack_comp_true_pair_E->Draw("axis"); // Draw only axis
+  
+  unique_ptr<TLegend> leg_comp_true_pair_E (new TLegend(0.55, 0.69, 0.9, 0.91));
+  
+  leg_comp_true_pair_E->SetHeader("Generator level");
+  leg_comp_true_pair_E->AddEntry(clone_true_pair_E_lowQ2, "m_{VV} < 500GeV", "l");
+  leg_comp_true_pair_E->AddEntry(clone_true_pair_E_highQ2, "m_{VV} > 500GeV", "l");
+  // 
+  // stack_comp_true_pair_E->Draw("axis same"); // Draw only axis
+  // 
+  stack_comp_true_pair_E->Draw("hist nostack");
+  leg_comp_true_pair_E->Draw();
+  
+  double max_comp_true_pair_E = std::max(clone_true_pair_E_lowQ2->GetMaximum(),clone_true_pair_E_highQ2->GetMaximum());
+  
+  double comp_true_pair_E_old_left_margin = canvas_comp_true_pair_E->GetLeftMargin();
+  scale_canvas_constant_pad(canvas_comp_true_pair_E, 1.04, "left");
+  stack_comp_true_pair_E->GetYaxis()->SetTitleOffset( stack_comp_true_pair_E->GetYaxis()->GetTitleOffset() * canvas_comp_true_pair_E->GetLeftMargin()/comp_true_pair_E_old_left_margin );
+
+  double comp_true_pair_E_old_bottom_margin = canvas_comp_true_pair_E->GetBottomMargin();
+  scale_canvas_constant_pad(canvas_comp_true_pair_E, 1.02, "bottom");
+  stack_comp_true_pair_E->GetXaxis()->SetTitleOffset( stack_comp_true_pair_E->GetXaxis()->GetTitleOffset() * canvas_comp_true_pair_E->GetBottomMargin()/comp_true_pair_E_old_bottom_margin );
+  
+  stack_comp_true_pair_E->SetMaximum( max_comp_true_pair_E * 1.17 );
+  // 
+  shared_ptr<TLatex> comp_true_pair_E_logo = add_ILD_mark( canvas_comp_true_pair_E, 50, 1.03 * max_comp_true_pair_E, 0.1);
+  // shared_ptr<TLatex> comp_true_pair_E_prelim = add_prelim_mark( canvas_comp_true_pair_E, 180, 1.17 * max_comp_true_pair_E, 0.07); 
+
+  string plot_name_comp_true_pair_E = "./comp_true_pair_E";
+  canvas_comp_true_pair_E->Print((output_dir + plot_name_comp_true_pair_E + ".pdf").c_str());
+  canvas_comp_true_pair_E->Print((output_dir + plot_name_comp_true_pair_E + ".jpg").c_str());
+  canvas_comp_true_pair_E->Print((output_dir + plot_name_comp_true_pair_E + ".C").c_str());
+  // ---------------------------------------------------------------------------
+  
+  // ---------------------------------------------------------------------------
+  double canvas_comp_true_pair_theta_height = 1200;
+  double canvas_comp_true_pair_theta_width  = 1200;
+
+  shared_ptr<TCanvas> canvas_comp_true_pair_theta (new TCanvas("canvas_comp_true_pair_theta", "", 0, 0, canvas_comp_true_pair_theta_width, canvas_comp_true_pair_theta_height));
+  shared_ptr<THStack> stack_comp_true_pair_theta = make_shared<THStack>( "comp_true_pair_theta", "; #theta_{V(qq)} [rad]; a.u." );
+
+  TH1D* clone_true_pair_theta_lowQ2 = (TH1D*)true_pair_theta_lowQ2->Clone();  clone_true_pair_theta_lowQ2->SetName((string(clone_true_pair_theta_lowQ2->GetName())+"_clone").c_str());  deletables.push_back(clone_true_pair_theta_lowQ2); clone_true_pair_theta_lowQ2->Scale(1.0/clone_true_pair_theta_lowQ2->Integral());
+  TH1D* clone_true_pair_theta_highQ2 = (TH1D*)true_pair_theta_highQ2->Clone();  clone_true_pair_theta_highQ2->SetName((string(clone_true_pair_theta_highQ2->GetName())+"_clone").c_str());  deletables.push_back(clone_true_pair_theta_highQ2); clone_true_pair_theta_highQ2->Scale(1.0/clone_true_pair_theta_highQ2->Integral());
+  
+  stack_comp_true_pair_theta->Add(clone_true_pair_theta_lowQ2);  clone_true_pair_theta_lowQ2->SetLineColor(9124);    clone_true_pair_theta_lowQ2->SetLineWidth(3);  clone_true_pair_theta_lowQ2->SetLineStyle(1);
+  stack_comp_true_pair_theta->Add(clone_true_pair_theta_highQ2);  clone_true_pair_theta_highQ2->SetLineColor(9024);   clone_true_pair_theta_highQ2->SetLineWidth(3);  clone_true_pair_theta_highQ2->SetLineStyle(1);
+  // stack_comp_true_pair_theta->Draw("axis"); // Draw only axis
+  
+  unique_ptr<TLegend> leg_comp_true_pair_theta (new TLegend(0.4, 0.71, 0.8, 0.91));
+
+  leg_comp_true_pair_theta->SetHeader("Generator level");
+  leg_comp_true_pair_theta->AddEntry(clone_true_pair_theta_lowQ2, "m_{VV} < 500GeV", "l");
+  leg_comp_true_pair_theta->AddEntry(clone_true_pair_theta_highQ2, "m_{VV} > 500GeV", "l");
+  // 
+  // stack_comp_true_pair_theta->Draw("axis same"); // Draw only axis
+  // 
+  stack_comp_true_pair_theta->Draw("hist nostack");
+  leg_comp_true_pair_theta->Draw();
+  
+  double max_comp_true_pair_theta = std::max(clone_true_pair_theta_lowQ2->GetMaximum(),clone_true_pair_theta_highQ2->GetMaximum());
+  
+  double comp_true_pair_theta_old_left_margin = canvas_comp_true_pair_theta->GetLeftMargin();
+  scale_canvas_constant_pad(canvas_comp_true_pair_theta, 1.04, "left");
+  stack_comp_true_pair_theta->GetYaxis()->SetTitleOffset( stack_comp_true_pair_theta->GetYaxis()->GetTitleOffset() * canvas_comp_true_pair_theta->GetLeftMargin()/comp_true_pair_theta_old_left_margin );
+
+  double comp_true_pair_theta_old_bottom_margin = canvas_comp_true_pair_theta->GetBottomMargin();
+  scale_canvas_constant_pad(canvas_comp_true_pair_theta, 1.02, "bottom");
+  stack_comp_true_pair_theta->GetXaxis()->SetTitleOffset( stack_comp_true_pair_theta->GetXaxis()->GetTitleOffset() * canvas_comp_true_pair_theta->GetBottomMargin()/comp_true_pair_theta_old_bottom_margin );
+  
+  stack_comp_true_pair_theta->SetMaximum( max_comp_true_pair_theta * 1.17 );
+  // 
+  shared_ptr<TLatex> comp_true_pair_theta_logo = add_ILD_mark( canvas_comp_true_pair_theta, 0.2, 1.03 * max_comp_true_pair_theta, 0.1);
+  // shared_ptr<TLatex> comp_true_pair_theta_prelim = add_prelim_mark( canvas_comp_true_pair_theta, 0.9, 1.03 * max_comp_true_pair_theta, 0.07); 
+
+  string plot_name_comp_true_pair_theta = "./comp_true_pair_theta";
+  canvas_comp_true_pair_theta->Print((output_dir + plot_name_comp_true_pair_theta + ".pdf").c_str());
+  canvas_comp_true_pair_theta->Print((output_dir + plot_name_comp_true_pair_theta + ".jpg").c_str());
+  canvas_comp_true_pair_theta->Print((output_dir + plot_name_comp_true_pair_theta + ".C").c_str());
+  // ---------------------------------------------------------------------------
+  
+  // ---------------------------------------------------------------------------
+  double canvas_comp_jet_E_height = 1200;
+  double canvas_comp_jet_E_width  = 1250;
+
+  shared_ptr<TCanvas> canvas_comp_jet_E (new TCanvas("canvas_comp_jet_E", "", 0, 0, canvas_comp_jet_E_width, canvas_comp_jet_E_height));
+  shared_ptr<THStack> stack_comp_jet_E = make_shared<THStack>( "comp_jet_E", "; E_{jet} [GeV]; a.u." );
+
+  TH1D* clone_jet_E_lowQ2 = (TH1D*)jet_E_lowQ2->Clone();  clone_jet_E_lowQ2->SetName((string(clone_jet_E_lowQ2->GetName())+"_clone").c_str());  deletables.push_back(clone_jet_E_lowQ2); clone_jet_E_lowQ2->Scale(1.0/clone_jet_E_lowQ2->Integral()); clone_jet_E_lowQ2->Rebin(4);
+  TH1D* clone_jet_E_highQ2 = (TH1D*)jet_E_highQ2->Clone();  clone_jet_E_highQ2->SetName((string(clone_jet_E_highQ2->GetName())+"_clone").c_str());  deletables.push_back(clone_jet_E_highQ2); clone_jet_E_highQ2->Scale(1.0/clone_jet_E_highQ2->Integral()); clone_jet_E_highQ2->Rebin(4);
+  
+  stack_comp_jet_E->Add(clone_jet_E_lowQ2);  clone_jet_E_lowQ2->SetLineColor(9124);    clone_jet_E_lowQ2->SetLineWidth(3);  clone_jet_E_lowQ2->SetLineStyle(1);
+  stack_comp_jet_E->Add(clone_jet_E_highQ2);  clone_jet_E_highQ2->SetLineColor(9024);   clone_jet_E_highQ2->SetLineWidth(3);  clone_jet_E_highQ2->SetLineStyle(1);
+  // stack_comp_jet_E->Draw("axis"); // Draw only axis
+  
+  unique_ptr<TLegend> leg_comp_jet_E (new TLegend(0.5, 0.7, 0.9, 0.9));
+  
+  leg_comp_jet_E->AddEntry(clone_jet_E_lowQ2, "m_{VV} < 500GeV", "l");
+  leg_comp_jet_E->AddEntry(clone_jet_E_highQ2, "m_{VV} > 500GeV", "l");
+  leg_comp_jet_E->SetHeader("e^{+}e^{-} #rightarrow #nu#bar{#nu}q#bar{q}q#bar{q}, 1TeV");
+  // 
+  // stack_comp_jet_E->Draw("axis same"); // Draw only axis
+  // 
+  leg_comp_jet_E->SetFillStyle(0);
+  stack_comp_jet_E->Draw("hist nostack");
+  leg_comp_jet_E->Draw();
+  
+  double max_comp_jet_E = std::max(clone_jet_E_lowQ2->GetMaximum(),clone_jet_E_highQ2->GetMaximum());
+  stack_comp_jet_E->SetMaximum( max_comp_jet_E * 1.3 );
+  double comp_jet_E_old_left_margin = canvas_comp_jet_E->GetLeftMargin();
+  adjust_canvas_left_to_square_pad(canvas_comp_jet_E);
+  stack_comp_jet_E->GetYaxis()->SetTitleOffset( stack_comp_jet_E->GetYaxis()->GetTitleOffset() * canvas_comp_jet_E->GetLeftMargin()/comp_jet_E_old_left_margin );
+  // 
+  shared_ptr<TLatex> comp_jet_E_logo = add_ILD_mark( canvas_comp_jet_E, 50, 1.13 * max_comp_jet_E, 0.1);
+  // shared_ptr<TLatex> comp_jet_E_prelim = add_prelim_mark( canvas_comp_jet_E, 180, 1.13 * max_comp_jet_E, 0.07); 
+
+  string plot_name_comp_jet_E = "./comp_jet_E";
+  canvas_comp_jet_E->Print((output_dir + plot_name_comp_jet_E + ".pdf").c_str());
+  canvas_comp_jet_E->Print((output_dir + plot_name_comp_jet_E + ".jpg").c_str());
+  canvas_comp_jet_E->Print((output_dir + plot_name_comp_jet_E + ".C").c_str());
+  // ---------------------------------------------------------------------------
+  
+  // ---------------------------------------------------------------------------
+  double canvas_comp_jet_theta_height = 1200;
+  double canvas_comp_jet_theta_width  = 1250;
+
+  shared_ptr<TCanvas> canvas_comp_jet_theta (new TCanvas("canvas_comp_jet_theta", "", 0, 0, canvas_comp_jet_theta_width, canvas_comp_jet_theta_height));
+  shared_ptr<THStack> stack_comp_jet_theta = make_shared<THStack>( "comp_jet_theta", "; #theta_{jet} [rad]; a.u." );
+
+  TH1D* clone_jet_theta_lowQ2 = (TH1D*)jet_theta_lowQ2->Clone();  clone_jet_theta_lowQ2->SetName((string(clone_jet_theta_lowQ2->GetName())+"_clone").c_str());  deletables.push_back(clone_jet_theta_lowQ2); clone_jet_theta_lowQ2->Scale(1.0/clone_jet_theta_lowQ2->Integral()); clone_jet_theta_lowQ2->Rebin(2);
+  TH1D* clone_jet_theta_highQ2 = (TH1D*)jet_theta_highQ2->Clone();  clone_jet_theta_highQ2->SetName((string(clone_jet_theta_highQ2->GetName())+"_clone").c_str());  deletables.push_back(clone_jet_theta_highQ2); clone_jet_theta_highQ2->Scale(1.0/clone_jet_theta_highQ2->Integral()); clone_jet_theta_highQ2->Rebin(2);
+  
+  stack_comp_jet_theta->Add(clone_jet_theta_lowQ2);  clone_jet_theta_lowQ2->SetLineColor(9124);    clone_jet_theta_lowQ2->SetLineWidth(3);  clone_jet_theta_lowQ2->SetLineStyle(1);
+  stack_comp_jet_theta->Add(clone_jet_theta_highQ2);  clone_jet_theta_highQ2->SetLineColor(9024);   clone_jet_theta_highQ2->SetLineWidth(3);  clone_jet_theta_highQ2->SetLineStyle(1);
+  // stack_comp_jet_theta->Draw("axis"); // Draw only axis
+  
+  unique_ptr<TLegend> leg_comp_jet_theta (new TLegend(0.45, 0.7, 0.85, 0.9));
+  
+  leg_comp_jet_theta->AddEntry(clone_jet_theta_lowQ2, "m_{VV} < 500GeV", "l");
+  leg_comp_jet_theta->AddEntry(clone_jet_theta_highQ2, "m_{VV} > 500GeV", "l");
+  leg_comp_jet_theta->SetHeader("e^{+}e^{-} #rightarrow #nu#bar{#nu}q#bar{q}q#bar{q}, 1TeV");
+
+  // 
+  // stack_comp_jet_theta->Draw("axis same"); // Draw only axis
+  // 
+  leg_comp_jet_theta->SetFillStyle(0);
+  stack_comp_jet_theta->Draw("hist nostack");
+  leg_comp_jet_theta->Draw();
+  
+  double max_comp_jet_theta = std::max(clone_jet_theta_lowQ2->GetMaximum(),clone_jet_theta_highQ2->GetMaximum());
+  stack_comp_jet_theta->SetMaximum( max_comp_jet_theta * 1.15 );
+  double comp_jet_theta_old_left_margin = canvas_comp_jet_theta->GetLeftMargin();
+  adjust_canvas_left_to_square_pad(canvas_comp_jet_theta);
+  stack_comp_jet_theta->GetYaxis()->SetTitleOffset( stack_comp_jet_theta->GetYaxis()->GetTitleOffset() * canvas_comp_jet_theta->GetLeftMargin()/comp_jet_theta_old_left_margin );
+  // 
+  shared_ptr<TLatex> comp_jet_theta_logo = add_ILD_mark( canvas_comp_jet_theta, 0.2, 1.02 * max_comp_jet_theta, 0.1);
+  // shared_ptr<TLatex> comp_jet_theta_prelim = add_prelim_mark( canvas_comp_jet_theta, 0.9, 1.02 * max_comp_jet_theta, 0.07); 
+
+  string plot_name_comp_jet_theta = "./comp_jet_theta";
+  canvas_comp_jet_theta->Print((output_dir + plot_name_comp_jet_theta + ".pdf").c_str());
+  canvas_comp_jet_theta->Print((output_dir + plot_name_comp_jet_theta + ".jpg").c_str());
+  canvas_comp_jet_theta->Print((output_dir + plot_name_comp_jet_theta + ".C").c_str());
+  // ---------------------------------------------------------------------------
+  
+
+  for ( auto & deletable: deletables ) { delete deletable; }
+  for ( auto & closable: closables ) { closable->Close(); }
+}

--- a/FinalStateAnalysis/analysis/comparisons/comparison_separation_curves/create_separation_curve_comparison.cpp
+++ b/FinalStateAnalysis/analysis/comparisons/comparison_separation_curves/create_separation_curve_comparison.cpp
@@ -1,5 +1,9 @@
 // WARNING: Needs to be run with ROOT 6.14 or newer! (Else creating .C files is a meeeeeess)
 
+//------------------------------------------------------------------------------
+#include "../Helpers/Helpers.hpp"
+//------------------------------------------------------------------------------
+
 float string_to_float( string str ) {
   return strtof((str).c_str(),0);
 }
@@ -34,9 +38,12 @@ void create_separation_curve_comparison() {
   gStyle->SetOptStat(0);
   TH2::SetDefaultSumw2();
 
-  string l5_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/nunu_hadron/fullQ2range/v02-00-02_l5_o1_v02_output/separation_curves/";
-  string s5_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/nunu_hadron/fullQ2range/v02-00-02_s5_o1_v02_output/separation_curves/";
-  string output_dir   = "/afs/desy.de/group/flc/pool/beyerjac/VBS/nunu_hadron/fullQ2range/comparisons/comparison_separation_curves/";
+  // string pool_dir = "/afs/desy.de/group/flc/pool/beyerjac"
+  string pool_dir = "/home/jakob/Documents/DESY/MountPoints/POOLMount";
+
+  string l5_directory = pool_dir + "/VBS/nunu_hadron/lowQ2range/v02-00-02_l5_o1_v02_output/separation_curves/";
+  string s5_directory = pool_dir + "/VBS/nunu_hadron/lowQ2range/v02-00-02_s5_o1_v02_output/separation_curves/";
+  string output_dir   = pool_dir + "/VBS/nunu_hadron/lowQ2range/comparisons/comparison_separation_curves/";
 
   shared_ptr<TFile> file_l5             = make_shared<TFile>( (l5_directory + "./_all_TGraphs.root").c_str() ) ;
   shared_ptr<TFile> file_s5             = make_shared<TFile>( (s5_directory + "./_all_TGraphs.root").c_str() ) ;
@@ -160,8 +167,7 @@ void create_separation_curve_comparison() {
   level_tex_reco_area->Draw();
 
   string plot_name_sep_curve_comp_reco = "./sep_curve_comp_reco";
-  canvas_sep_curve_comp_reco->Print((output_dir + plot_name_sep_curve_comp_reco + ".pdf").c_str());
-  canvas_sep_curve_comp_reco->Print((output_dir + plot_name_sep_curve_comp_reco + ".C").c_str());
+  Helpers::saveCanvas(canvas_sep_curve_comp_reco, output_dir + plot_name_sep_curve_comp_reco);
 
   // ---------------------------------------------------------------------------
   
@@ -258,8 +264,7 @@ void create_separation_curve_comparison() {
   level_tex_cheatjet_area->Draw();
 
   string plot_name_sep_curve_comp_cheatjet = "./sep_curve_comp_cheatjet";
-  canvas_sep_curve_comp_cheatjet->Print((output_dir + plot_name_sep_curve_comp_cheatjet + ".pdf").c_str());
-  canvas_sep_curve_comp_cheatjet->Print((output_dir + plot_name_sep_curve_comp_cheatjet + ".C").c_str());
+  Helpers::saveCanvas(canvas_sep_curve_comp_cheatjet, output_dir + plot_name_sep_curve_comp_cheatjet);
 
   // ---------------------------------------------------------------------------
   
@@ -307,8 +312,7 @@ void create_separation_curve_comparison() {
   // shared_ptr<TLatex> sep_curve_comp_l5_prelim = add_prelim_mark( canvas_sep_curve_comp_l5, 0.28, 0.65, 0.07); 
   
   string plot_name_sep_curve_comp_l5 = "./sep_curve_comp_l5";
-  canvas_sep_curve_comp_l5->Print((output_dir + plot_name_sep_curve_comp_l5 + ".pdf").c_str());
-  canvas_sep_curve_comp_l5->Print((output_dir + plot_name_sep_curve_comp_l5 + ".C").c_str());
+  Helpers::saveCanvas(canvas_sep_curve_comp_l5, output_dir + plot_name_sep_curve_comp_l5);
 
   // ---------------------------------------------------------------------------
   
@@ -361,8 +365,7 @@ void create_separation_curve_comparison() {
   // shared_ptr<TLatex> sep_curve_comp_l5_IDR_prelim = add_prelim_mark( canvas_sep_curve_comp_l5_IDR, 0.28, 0.65, 0.07); 
   
   string plot_name_sep_curve_comp_l5_IDR = "./sep_curve_comp_l5_IDR";
-  canvas_sep_curve_comp_l5_IDR->Print((output_dir + plot_name_sep_curve_comp_l5_IDR + ".pdf").c_str());
-  canvas_sep_curve_comp_l5_IDR->Print((output_dir + plot_name_sep_curve_comp_l5_IDR + ".C").c_str());
+  Helpers::saveCanvas(canvas_sep_curve_comp_l5_IDR, output_dir + plot_name_sep_curve_comp_l5_IDR);
 
   // ---------------------------------------------------------------------------
   
@@ -415,8 +418,7 @@ void create_separation_curve_comparison() {
   // shared_ptr<TLatex> sep_curve_comp_s5_IDR_prelim = add_prelim_mark( canvas_sep_curve_comp_s5_IDR, 0.28, 0.65, 0.07); 
   
   string plot_name_sep_curve_comp_s5_IDR = "./sep_curve_comp_s5_IDR";
-  canvas_sep_curve_comp_s5_IDR->Print((output_dir + plot_name_sep_curve_comp_s5_IDR + ".pdf").c_str());
-  canvas_sep_curve_comp_s5_IDR->Print((output_dir + plot_name_sep_curve_comp_s5_IDR + ".C").c_str());
+  Helpers::saveCanvas(canvas_sep_curve_comp_s5_IDR, output_dir + plot_name_sep_curve_comp_s5_IDR);
 
   // ---------------------------------------------------------------------------
   
@@ -481,8 +483,7 @@ void create_separation_curve_comparison() {
   // shared_ptr<TLatex> sep_curve_comp_ls_IDR_prelim = add_prelim_mark( canvas_sep_curve_comp_ls_IDR, 0.28, 0.65, 0.07); 
   
   string plot_name_sep_curve_comp_ls_IDR = "./sep_curve_comp_ls_IDR";
-  canvas_sep_curve_comp_ls_IDR->Print((output_dir + plot_name_sep_curve_comp_ls_IDR + ".pdf").c_str());
-  canvas_sep_curve_comp_ls_IDR->Print((output_dir + plot_name_sep_curve_comp_ls_IDR + ".C").c_str());
+  Helpers::saveCanvas(canvas_sep_curve_comp_ls_IDR, output_dir + plot_name_sep_curve_comp_ls_IDR);
 
   // ---------------------------------------------------------------------------
   

--- a/FinalStateAnalysis/analysis/comparisons/comparisons_ls_and_cheated/create_detector_and_icn_VV_m_comparison.cpp
+++ b/FinalStateAnalysis/analysis/comparisons/comparisons_ls_and_cheated/create_detector_and_icn_VV_m_comparison.cpp
@@ -172,10 +172,13 @@ void create_detector_and_icn_VV_m_comparison() {
   gStyle->SetOptStat(0);
   TH2::SetDefaultSumw2();
 
-  string output_dir = "/afs/desy.de/group/flc/pool/beyerjac/VBS/nunu_hadron/fullQ2range/comparisons/comparisons_ls_and_cheated/";
+  // string pool_dir = "/afs/desy.de/group/flc/pool/beyerjac"
+  string pool_dir = "/home/jakob/Documents/DESY/MountPoints/POOLMount";
 
-  string l5_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/nunu_hadron/fullQ2range/v02-00-02_l5_o1_v02_output"; 
-  string s5_directory = "/afs/desy.de/group/flc/pool/beyerjac/VBS/nunu_hadron/fullQ2range/v02-00-02_s5_o1_v02_output"; 
+  string output_dir = pool_dir + "/VBS/nunu_hadron/highQ2range/comparisons/comparisons_ls_and_cheated/";
+
+  string l5_directory = pool_dir + "/VBS/nunu_hadron/highQ2range/v02-00-02_l5_o1_v02_output"; 
+  string s5_directory = pool_dir + "/VBS/nunu_hadron/highQ2range/v02-00-02_s5_o1_v02_output"; 
 
   shared_ptr<TFile> file_l5             = make_shared<TFile>( (l5_directory + "/mjjmjj_plots/_all_TH1Ds.root").c_str() ) ;
   shared_ptr<TFile> file_l5_2D          = make_shared<TFile>( (l5_directory + "/mjjmjj_plots/_all_TH2Ds.root").c_str() ) ;

--- a/FinalStateAnalysis/analysis/complete_plotting/include/EventSkipper.h
+++ b/FinalStateAnalysis/analysis/complete_plotting/include/EventSkipper.h
@@ -1,0 +1,33 @@
+#ifndef EVENTSKIPPER_H
+#define EVENTSKIPPER_H 1
+
+#include "TBranch.h"
+#include "TTree.h"
+
+class EventSkipper {
+  /** Class to that allows skipping specific events in a tree.
+   **/
+   
+  float m_VV_mass {};
+  
+  bool m_low_mVV_only {false};
+public:
+  // Constructor
+  EventSkipper(){}
+  
+  // Instructions on which events to use
+  void UseLowMVVOnly() { m_low_mVV_only = true; }
+  
+  // Check if an event needs to be skipped
+  bool should_skip_event(	TTree* tree, int event_number ) {
+    bool skip = false;
+    if (m_low_mVV_only) {
+      tree->GetBranch("true_observables")->GetLeaf("VV_mass")->SetAddress(&m_VV_mass);
+      tree->GetEntry(event_number);
+      if (m_VV_mass > 500) {skip = true;}
+    }
+    return skip;
+  }
+};
+
+#endif

--- a/FinalStateAnalysis/analysis/complete_plotting/include/plotter.h
+++ b/FinalStateAnalysis/analysis/complete_plotting/include/plotter.h
@@ -228,12 +228,6 @@ class Plotter {
 		// If counter within size of tree -> get next event
 		// Otherwise return false -> stop
 		if ( current_event_number < current_tree->GetEntries() ) {
-      // Check if this event ought to be used at all
-      if (event_skipper.should_skip_event(current_tree, current_event_number)) {
-        current_event_number++; // Increment to next event
-        get_next_event();
-      }
-
 			// Get new array sizes
 			current_tree->GetBranch("max_Njets")->GetEntry(current_event_number);
 			current_tree->GetBranch("max_Nparticles")->GetEntry(current_event_number);
@@ -243,8 +237,14 @@ class Plotter {
 			// Includes global GetEntry for all variables
 			set_dynamic_addresses();
 
+      // Check if this event ought to be used at all
+      if (event_skipper.should_skip_event(current_tree, current_event_number)) {
+        current_event_number++; // Increment to next event
+        return get_next_event();
+      } else {
 			current_event_number++; // Increment to next event
 			return true;
+      }
 		} else {
 			return false;
 		}

--- a/FinalStateAnalysis/analysis/complete_plotting/include/plotter.h
+++ b/FinalStateAnalysis/analysis/complete_plotting/include/plotter.h
@@ -1,5 +1,6 @@
 #ifndef PLOTTER_h
 #define PLOTTER_h
+#include "EventSkipper.h"
 #include "InfoStorage.h"
 #include "../../../include/jet_corrections.h"
 
@@ -27,6 +28,9 @@ class Plotter {
 		// Return the plotter specific output directory
 		return info_storage.get_output_directory() + "/" + get_output_folder_name() ;
 	}
+
+  // Info on which events to skip
+  EventSkipper event_skipper {};
 
 	// Vectors for the possible diagrams (if new type needed: add it)
 	vector<TH1D*> TH1D_vector;
@@ -224,6 +228,11 @@ class Plotter {
 		// If counter within size of tree -> get next event
 		// Otherwise return false -> stop
 		if ( current_event_number < current_tree->GetEntries() ) {
+      // Check if this event ought to be used at all
+      if (event_skipper.should_skip_event(current_tree, current_event_number)) {
+        current_event_number++; // Increment to next event
+        get_next_event();
+      }
 
 			// Get new array sizes
 			current_tree->GetBranch("max_Njets")->GetEntry(current_event_number);

--- a/FinalStateAnalysis/analysis/complete_plotting/src/configuration.cpp
+++ b/FinalStateAnalysis/analysis/complete_plotting/src/configuration.cpp
@@ -69,4 +69,11 @@ void set_plotters(vector<Plotter*> &plotters) {
 	// plotters.push_back( new TJJetEnergyResolutionPlotter );
 	// plotters.push_back( new SeparationCurvePlotter );
 	/* ---------------------------------------------------------------------*/
+  
+  /* ---------------------------------------------------------------------*/
+  // Determine which events to skip
+  for (auto plotter: plotters) {
+    plotter.event_skipper.UseLowMVVOnly();
+  }
+  /* ---------------------------------------------------------------------*/
 }

--- a/FinalStateAnalysis/analysis/complete_plotting/src/configuration.cpp
+++ b/FinalStateAnalysis/analysis/complete_plotting/src/configuration.cpp
@@ -38,36 +38,36 @@ void set_plotters(vector<Plotter*> &plotters) {
 	// INSERT THE PLOTTER MODULES HERE
 
 
-  // plotters.push_back( new AllSignalsPlotter );
-  // plotters.push_back( new TJObservToICNsPlotter );
-  // plotters.push_back( new TJObservToICNsOnlyUDSPlotter );
-  // plotters.push_back( new TJObservToICNsOnlyUDSCPlotter );
-	// plotters.push_back( new TestPlotter );
-	// plotters.push_back( new MjjMjjPlotter );
-	// plotters.push_back( new MjjVsSLDecaysPlotter );
-	// plotters.push_back( new ThetaMPlotter );
-	// plotters.push_back( new TrueISRvsMjjPlotter );
-	// plotters.push_back( new TailPlotter );
-	// plotters.push_back( new AllSelectedPlotter );
-	// plotters.push_back( new RecoMjjVSQuarkPDGPlotter );
+    plotters.push_back( new AllSignalsPlotter );
+    plotters.push_back( new TJObservToICNsPlotter );
+    plotters.push_back( new TJObservToICNsOnlyUDSPlotter );
+    plotters.push_back( new TJObservToICNsOnlyUDSCPlotter );
+	plotters.push_back( new TestPlotter );
+	plotters.push_back( new MjjMjjPlotter );
+	plotters.push_back( new MjjVsSLDecaysPlotter );
+	plotters.push_back( new ThetaMPlotter );
+	plotters.push_back( new TrueISRvsMjjPlotter );
+	plotters.push_back( new TailPlotter );
+	plotters.push_back( new AllSelectedPlotter );
+	plotters.push_back( new RecoMjjVSQuarkPDGPlotter );
 	plotters.push_back( new IndividualJetsPlotter );
-	// plotters.push_back( new CutflowPlotter );
-	// plotters.push_back( new TJJetLevelsPlotter );
-	// plotters.push_back( new TJJetMassInvestigationPlotter );
-	// plotters.push_back( new TJLeptonsInJetsPlotter );
-	// plotters.push_back( new TJChargedHadronsInJetsPlotter );
-	// plotters.push_back( new TJNeutralHadronsInJetsPlotter );
-	// plotters.push_back( new TJPhotonsInJetsPlotter );
-	// plotters.push_back( new TJNParticlesPlotter );
-	// plotters.push_back( new TJSeenTrueOfSeenECorrectionPlotter );
-	// plotters.push_back( new TJSeenTrueOfSeenPCorrectionPlotter );
-	// plotters.push_back( new TJCorrectedJetsPlotter );
-	// plotters.push_back( new TJCorrectedLowEJetsPlotter );
-	// plotters.push_back( new TJChargedHadronsInCorrectedJetsPlotter );
-	// plotters.push_back( new TJQuarkJetsPlusNeutrinosPlotter );
-	// plotters.push_back( new TJTotalEPlotter );
-	// plotters.push_back( new TJJetEnergyResolutionPlotter );
-	// plotters.push_back( new SeparationCurvePlotter );
+	plotters.push_back( new CutflowPlotter );
+	plotters.push_back( new TJJetLevelsPlotter );
+	plotters.push_back( new TJJetMassInvestigationPlotter );
+	plotters.push_back( new TJLeptonsInJetsPlotter );
+	plotters.push_back( new TJChargedHadronsInJetsPlotter );
+	plotters.push_back( new TJNeutralHadronsInJetsPlotter );
+	plotters.push_back( new TJPhotonsInJetsPlotter );
+	plotters.push_back( new TJNParticlesPlotter );
+	plotters.push_back( new TJSeenTrueOfSeenECorrectionPlotter );
+	plotters.push_back( new TJSeenTrueOfSeenPCorrectionPlotter );
+	plotters.push_back( new TJCorrectedJetsPlotter );
+	plotters.push_back( new TJCorrectedLowEJetsPlotter );
+	plotters.push_back( new TJChargedHadronsInCorrectedJetsPlotter );
+	plotters.push_back( new TJQuarkJetsPlusNeutrinosPlotter );
+	plotters.push_back( new TJTotalEPlotter );
+	plotters.push_back( new TJJetEnergyResolutionPlotter );
+	plotters.push_back( new SeparationCurvePlotter );
 	/* ---------------------------------------------------------------------*/
   
   /* ---------------------------------------------------------------------*/

--- a/FinalStateAnalysis/analysis/complete_plotting/src/configuration.cpp
+++ b/FinalStateAnalysis/analysis/complete_plotting/src/configuration.cpp
@@ -69,4 +69,11 @@ void set_plotters(vector<Plotter*> &plotters) {
 	// plotters.push_back( new TJJetEnergyResolutionPlotter );
 	// plotters.push_back( new SeparationCurvePlotter );
 	/* ---------------------------------------------------------------------*/
+  
+  /* ---------------------------------------------------------------------*/
+  // Determine which events to skip
+  for (auto plotter: plotters) {
+    plotter->event_skipper.UseLowMVVOnly();
+  }
+  /* ---------------------------------------------------------------------*/
 }

--- a/FinalStateAnalysis/include/InformationStorages/EventInformation.h
+++ b/FinalStateAnalysis/include/InformationStorages/EventInformation.h
@@ -56,6 +56,7 @@ class Observables {
 		float pair1_p;
 		float pair2_p;
 
+    float VV_mass; // combined mass of both bosons
 		float miss_mass; // Also called: recoil mass
 
 		float sum_E_q; // should be called sum_E_vis ...
@@ -97,6 +98,7 @@ class Observables {
 			pair1_p = -10;
 			pair2_p = -10;
 
+			VV_mass	= -10;
 			miss_mass	= -10;
 
 			sum_E_q		= -10;
@@ -131,6 +133,7 @@ class Observables {
 
 
 			visible_tlv = pair1_tlv + pair2_tlv;
+			VV_mass		= visible_tlv.M();
 			sum_E_q		= visible_tlv.E();
 			E_T_vis		= visible_tlv.Et();
 			p_T_vis		= visible_tlv.Pt();

--- a/FinalStateAnalysis/src/TreeBranches/ObservablesBranch.cc
+++ b/FinalStateAnalysis/src/TreeBranches/ObservablesBranch.cc
@@ -10,6 +10,7 @@ void JakobsVBSProcessor::CreateObservablesBranch( TTree* tree, Observables* obse
 					"pair2_theta/F:" +
 					"pair1_p/F:" +
 					"pair2_p/F:" +
+					"VV_mass/F:" +
 					"miss_mass/F:" +
 					"sum_E_q/F:" +
 					"E_T_vis/F:" +


### PR DESCRIPTION
- Add the m_VV mass as an observable in the FinalStateAnalysis processor.
- Enable event skipping in analysis.
- Enable event skipping in analysis.
- Fix bug in setting MVV skip in configuration of analysis.
- Fix bug in analysis that didn't properly skip events.
- Add a new comparison of the high Q2 and low Q2 events / samples.
- Add namespace for common helper functions for the comparisons.
- Use new helper function in comparison macros.